### PR TITLE
Make changes required by ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+exclude_paths:
+  - .github
+  - vm-testing

--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,0 +1,15 @@
+name: Run ansible-lint
+on:
+  push:
+  pull_request:
+
+jobs:
+  ansible-lint:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+        - name: Run ansible-lint
+          run: |
+            pip install -r requirements-testing.txt
+            ansible-lint -v

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2024] [RedHat]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# sigstore-ansible
+# artifact-signer-ansible
 
-Automation to deploy the sigstore ecosystem on RHEL
+Automation to deploy the RHTAS ecosystem on RHEL
 
 :warning: **The contents of this repository are a Work in Progress.**
 
 ## Overview
 
-The automation within this repository establishes the components of the [Sigstore project](https://sigstore.dev) within a single
+The automation within this repository establishes the components of RHTAS, the downstream redistribution of  [Sigstore project](https://sigstore.dev) within a single
 Red Hat Enterprise Linux (RHEL) machine using a standalone containerized deployment.
 Containers are spawned using Kubernetes based manifests using
 [podman kube play](https://docs.podman.io/en/latest/markdown/podman-kube-play.1.html).
@@ -54,7 +54,7 @@ The automation deploys and configures a software load balancer as a central poin
 * https://fulcio.<base_hostname>
 * https://tuf.<base_hostname>
 
-Each of these hostnames must be configured in DNS to resolve to the target machine. The `base_hostname` parameter must be provided
+each of these hostnames must be configured in DNS to resolve to the target machine. The `base_hostname` parameter must be provided
 when executing the provisining. To configure hostnames in DNS, edit `/etc/hosts` with the following content:
 
 ```
@@ -85,8 +85,8 @@ Download the _root_ certiicate that issued the rekor certificate.
 In Red Hat based systems, the following commands will add a CA to the system truststore.
 
 ```shell
-$ sudo openssl x509 -in ~/Downloads/root-cert-from-browser -out sigstore-ca.pem --outform PEM
-$ sudo mv sigstore-ca.pem /etc/pki/ca-trust/source/anchors/
+$ sudo openssl x509 -in ~/Downloads/root-cert-from-browser -out tas-ca.pem --outform PEM
+$ sudo mv tas-ca.pem /etc/pki/ca-trust/source/anchors/
 $ sudo update-ca-trust
 ```
 
@@ -97,7 +97,7 @@ Utilize the following steps to sign a container that has been published to an OC
 1. Export the following environment variables substituting `base_hostname` with the value used as part of the provisioning
 
 ```shell
-export KEYCLOAK_REALM=sigstore
+export KEYCLOAK_REALM=trusted-artifact-signer
 export BASE_HOSTNAME=<base_hostname>
 export FULCIO_URL=https://fulcio.$BASE_HOSTNAME
 export KEYCLOAK_URL=https://keycloak.$BASE_HOSTNAME
@@ -142,4 +142,4 @@ This repository contains GitHub actions that will test PRs that come in by creat
 
 ## Feedback
 
-Any and all feedback is welcomed. Submit an [Issue](https://github.com/securesign/sigstore-ansible/issues) or [Pull Request](https://github.com/securesign/sigstore-ansible/pulls) as desired.
+Any and all feedback is welcomed. Submit an [Issue](https://github.com/securesign/artifact-signer-ansible/issues) or [Pull Request](https://github.com/securesign/artifact-signer-ansible/pulls) as desired.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ authors:
   - Red Hat
   - TODO
 description: TODO
-license_file: TODO
+license_file: Apache-2.0
 tags: [sigstore, tas, rhtas, security, cosign]
 dependencies: {}
 repository: https://github.com/securesign/sigstore-ansible/

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,9 +11,9 @@ description: TODO
 license_file: Apache-2.0
 tags: [sigstore, tas, rhtas, security, cosign]
 dependencies: {}
-repository: https://github.com/securesign/sigstore-ansible/
+repository: https://github.com/securesign/artifact-signer-ansible/
 documentation: http://TODO.com
 homepage: https://TODO.com
-issues: https://github.com/securesign/sigstore-ansible/issues
+issues: https://github.com/securesign/artifact-signer-ansible/issues
 
 build_ignore: [.ansible-lint, .github, .gitignore, .vscode, requirements-testing.txt, vm-testing]

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: redhat
 name: artifact_signer
-version: 0.0.1
+version: 1.0.0
 
 readme: README.md
 authors:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,10 +11,9 @@ description: TODO
 license_file: TODO
 tags: [sigstore, tas, rhtas, security, cosign]
 dependencies: {}
-
 repository: https://github.com/securesign/sigstore-ansible/
 documentation: http://TODO.com
 homepage: https://TODO.com
 issues: https://github.com/securesign/sigstore-ansible/issues
 
-build_ignore: [ansible.cfg, .github, .gitignore, .vscode, inventory, main.tf, playbooks, requirements.yml]
+build_ignore: [.ansible-lint, .github, .gitignore, .vscode, requirements-testing.txt, vm-testing]

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: '>=2.16.0'

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,0 +1,1 @@
+ansible-lint==24.6.1

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # defaults file for sigstore_scaffolding
 system_packages:
-    - podman
-    - podman-plugins
-    - firewalld
+  - podman
+  - podman-plugins
+  - firewalld
 
 sigstore_podman_network: sigstore
 
@@ -13,7 +13,7 @@ cockpit:
     - cockpit-storaged
     - cockpit-podman
     - cockpit
-  cockpit_manage_firewall: yes
+  cockpit_manage_firewall: true
 
 skip_os_install: false
 
@@ -29,18 +29,17 @@ trillian_enabled: true
 trillian:
   database_deploy: true
   mysql:
-   user: mysql
-   rootPassword: rootpassword
-   password: password
-   database: trillian
-   host: trillian-mysql-pod
-   port: 3306
+    user: mysql
+    rootPassword: rootpassword
+    password: password
+    database: trillian
+    host: trillian-mysql-pod
+    port: 3306
 
 config_dir: /etc/sigstore
 certs_dir: "{{ config_dir }}/certs"
 kube_manifest_dir: "{{ config_dir }}/manifests"
 kube_configmap_dir: "{{ config_dir }}/configs"
-
 
 local_certs_dir: /tmp/sigstore/certs
 
@@ -108,8 +107,8 @@ fulcio_server_image: quay.io/redhat-user-workloads/rhtas-tenant/fulcio/fulcio-se
 trillian_log_server_image: quay.io/redhat-user-workloads/rhtas-tenant/trillian/logserver@sha256:cdb2fa8ef85a9727c2b306652e4127ee4b2723cd361a04f364f4a96d60194777
 trillian_logsigner_image: quay.io/redhat-user-workloads/rhtas-tenant/trillian/logsigner@sha256:f8199e0b14f391574181a3e38659a2ec5baeb65ba5101ac63b5b9785ae01c214
 rekor_image: quay.io/redhat-user-workloads/rhtas-tenant/rekor/rekor-server@sha256:a2075576589bec3c4544db4368732cb1388e8f5a3cb2a739d943cee601e64b74
-ct_server_image: quay.io/redhat-user-workloads/rhtas-tenant/certificate-transparency-go/certificate-transparency-go@sha256:1419a048cb5095b3f65d08224e6f94c6eb166d8d5a16707942aed2880992ddee
-
+ct_server_image:
+  quay.io/redhat-user-workloads/rhtas-tenant/certificate-transparency-go/certificate-transparency-go@sha256:1419a048cb5095b3f65d08224e6f94c6eb166d8d5a16707942aed2880992ddee
 
 # Supplement images
 redis_image: quay.io/redhat-user-workloads/rhtas-tenant/trillian/redis@sha256:0804a6634b8836cb2e957ee16d54e8d6ab94d311362a48baf238b1f575d79934

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -1,13 +1,13 @@
 ---
-# defaults file for sigstore_scaffolding
-system_packages:
+# defaults file for tas_single_node
+tas_single_node_system_packages:
   - podman
   - podman-plugins
   - firewalld
 
-sigstore_podman_network: sigstore
+tas_single_node_podman_network: rhtas
 
-cockpit:
+tas_single_node_cockpit:
   enabled: true
   cockpit_packages:
     - cockpit-storaged
@@ -15,18 +15,18 @@ cockpit:
     - cockpit
   cockpit_manage_firewall: true
 
-skip_os_install: false
+tas_single_node_skip_os_install: false
 
-sigstore_rekor_templates:
+tas_single_node_rekor_templates:
   - manifests/rekor/redis-server.yaml
   - manifests/rekor/rekor-server.yaml
 
-cockpit_enabled: true
-ctlog_enabled: true
-tuf_enabled: true
-trillian_enabled: true
+tas_single_node_cockpit_enabled: true
+tas_single_node_ctlog_enabled: true
+tas_single_node_tuf_enabled: true
+tas_single_node_trillian_enabled: true
 
-trillian:
+tas_single_node_trillian:
   database_deploy: true
   mysql:
     user: mysql
@@ -36,84 +36,89 @@ trillian:
     host: trillian-mysql-pod
     port: 3306
 
-config_dir: /etc/sigstore
-certs_dir: "{{ config_dir }}/certs"
-kube_manifest_dir: "{{ config_dir }}/manifests"
-kube_configmap_dir: "{{ config_dir }}/configs"
+tas_single_node_config_dir: /etc/rhtas
+tas_single_node_certs_dir: "{{ tas_single_node_config_dir }}/certs"
+tas_single_node_kube_manifest_dir: "{{ tas_single_node_config_dir }}/manifests"
+tas_single_node_kube_configmap_dir: "{{ tas_single_node_config_dir }}/configs"
 
-local_certs_dir: /tmp/sigstore/certs
+tas_single_node_local_certs_dir: /tmp/rhtas/certs
 
-sigstore_private_key_filename: sigstore.key
-sigstore_ca_filename: sigstore.pem
-fulcio_private_key_filename: fulcio.key
-fulcio_public_key_filename: fulcio.pub
-fulcio_root_ca_filename: fulcio.pem
-ctlog_private_key_filename: ctlog.key
-ctlog_public_key_filename: ctlog.pub
-rekor_signer_filename: rekor-signer.key
-rekor_public_key_filename: rekor-pub-key.pub
+tas_single_node_private_key_filename: rhtas.key
+tas_single_node_ca_filename: rhtas.pem
+tas_single_node_fulcio_private_key_filename: fulcio.key
+tas_single_node_fulcio_public_key_filename: fulcio.pub
+tas_single_node_fulcio_root_ca_filename: fulcio.pem
+tas_single_node_ctlog_private_key_filename: ctlog.key
+tas_single_node_ctlog_public_key_filename: ctlog.pub
+tas_single_node_rekor_signer_filename: rekor-signer.key
+tas_single_node_rekor_public_key_filename: rekor-pub-key.pub
 
-local_sigstore_private_key: "{{ local_certs_dir }}/{{ sigstore_private_key_filename }}"
-local_sigstore_ca: "{{ local_certs_dir }}/{{ sigstore_ca_filename }}"
-local_fulcio_private_key: "{{ local_certs_dir }}/{{ fulcio_private_key_filename }}"
-local_fulcio_public_key: "{{ local_certs_dir }}/{{ fulcio_public_key_filename }}"
-local_fulcio_root_ca: "{{ local_certs_dir }}/{{ fulcio_root_ca_filename }}"
-local_ctlog_private_key: "{{ local_certs_dir }}/{{ ctlog_private_key_filename }}"
-local_ctlog_public_key: "{{ local_certs_dir }}/{{ ctlog_public_key_filename }}"
-local_rekor_signer: "{{ local_certs_dir }}/{{ rekor_signer_filename }}"
-local_rekor_public_key: "{{ local_certs_dir }}/{{ rekor_public_key_filename }}"
-remote_sigstore_private_key: "{{ certs_dir }}/{{ sigstore_private_key_filename }}"
-remote_sigstore_ca: "{{ certs_dir }}/{{ sigstore_ca_filename }}"
-remote_fulcio_private_key: "{{ certs_dir }}/{{ fulcio_private_key_filename }}"
-remote_fulcio_public_key: "{{ certs_dir }}/{{ fulcio_public_key_filename }}"
-remote_fulcio_root_ca: "{{ certs_dir }}/{{ fulcio_root_ca_filename }}"
-remote_ctlog_private_key: "{{ certs_dir }}/{{ ctlog_private_key_filename }}"
-remote_ctlog_public_key: "{{ certs_dir }}/{{ ctlog_public_key_filename }}"
-remote_rekor_signer: "{{ certs_dir }}/{{ rekor_signer_filename }}"
-remote_rekor_public_key: "{{ certs_dir }}/{{ rekor_public_key_filename }}"
+tas_single_node_local_private_key: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_private_key_filename }}"
+tas_single_node_local_ca: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_ca_filename }}"
+tas_single_node_local_fulcio_private_key: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_fulcio_private_key_filename }}"
+tas_single_node_local_fulcio_public_key: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_fulcio_public_key_filename }}"
+tas_single_node_local_fulcio_root_ca: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_fulcio_root_ca_filename }}"
+tas_single_node_local_ctlog_private_key: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_ctlog_private_key_filename }}"
+tas_single_node_local_ctlog_public_key: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_ctlog_public_key_filename }}"
+tas_single_node_local_rekor_signer: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_rekor_signer_filename }}"
+tas_single_node_local_rekor_public_key: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_rekor_public_key_filename }}"
+tas_single_node_remote_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_private_key_filename }}"
+tas_single_node_remote_ca: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_ca_filename }}"
+tas_single_node_remote_fulcio_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_fulcio_private_key_filename }}"
+tas_single_node_remote_fulcio_public_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_fulcio_public_key_filename }}"
+tas_single_node_remote_fulcio_root_ca: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_fulcio_root_ca_filename }}"
+tas_single_node_remote_ctlog_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_ctlog_private_key_filename }}"
+tas_single_node_remote_ctlog_public_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_ctlog_public_key_filename }}"
+tas_single_node_remote_rekor_signer: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_rekor_signer_filename }}"
+tas_single_node_remote_rekor_public_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_rekor_public_key_filename }}"
 
-rekor_enabled: true
-rekor_public_key_retries: 5
-rekor_public_key_delay: 10
-fulcio_server_config: "{{ kube_configmap_dir }}/fulcio-config.yaml"
-fulcio_server_secret_config: "{{ kube_configmap_dir }}/fulcio-server-secret.yaml"
-ctlog_secret: "{{ kube_configmap_dir }}/ctlog-secret.yaml"
-ctlog_configmap_config: "{{ kube_configmap_dir }}/ctlog-config.yaml"
-tuf_secret_config: "{{ kube_configmap_dir }}/tuf-secret.yaml"
-treeid_config: "{{ kube_configmap_dir }}/treeid-config.yaml"
-rekor_sharding_config: "{{ kube_configmap_dir }}/rekor-sharding-config.yaml"
-nginx_config: "{{ kube_configmap_dir }}/nginx-config.yaml"
-nginx_certs_config: "{{ kube_configmap_dir }}/nginx-certs.yaml"
-systemd_directory: /etc/systemd/system
+tas_single_node_rekor_enabled: true
+tas_single_node_rekor_public_key_retries: 5
+tas_single_node_rekor_public_key_delay: 10
+tas_single_node_fulcio_server_config: "{{ tas_single_node_kube_configmap_dir }}/fulcio-config.yaml"
+tas_single_node_fulcio_server_secret_config: "{{ tas_single_node_kube_configmap_dir }}/fulcio-server-secret.yaml"
+tas_single_node_ctlog_secret: "{{ tas_single_node_kube_configmap_dir }}/ctlog-secret.yaml"
+tas_single_node_ctlog_configmap_config: "{{ tas_single_node_kube_configmap_dir }}/ctlog-config.yaml"
+tas_single_node_tuf_secret_config: "{{ tas_single_node_kube_configmap_dir }}/tuf-secret.yaml"
+tas_single_node_treeid_config: "{{ tas_single_node_kube_configmap_dir }}/treeid-config.yaml"
+tas_single_node_rekor_sharding_config: "{{ tas_single_node_kube_configmap_dir }}/rekor-sharding-config.yaml"
+tas_single_node_nginx_config: "{{ tas_single_node_kube_configmap_dir }}/nginx-config.yaml"
+tas_single_node_nginx_certs_config: "{{ tas_single_node_kube_configmap_dir }}/nginx-certs.yaml"
+tas_single_node_systemd_directory: /etc/systemd/system
 
-setup_host_dns: true
-base_hostname: ""
+tas_single_node_setup_host_dns: true
+tas_single_node_base_hostname: ""
 
-fulcio_enabled: true
-fulcio_ca_passphrase: sigstore
-ctlog_ca_passphrase: sigstore
-rekor_ca_passphrase: sigstore
-ct_logprefix: sigstoreansible
+tas_single_node_fulcio_enabled: true
+tas_single_node_fulcio_ca_passphrase: rhtas
+tas_single_node_ctlog_ca_passphrase: rhtas
+tas_single_node_rekor_ca_passphrase: rhtas
+tas_single_node_ct_logprefix: rhtasansible
 
-scaffolding_utils_image: quay.io/ablock/sigstore-scaffolding-helper:latest
+tas_single_node_scaffolding_utils_image: quay.io/ablock/sigstore-scaffolding-helper:latest
 
-oidc_issuers: https://keycloak-keycloak-system.apps.platform-sts.pcbk.p1.openshiftapps.com/auth/realms/trusted-artifact-signer
-sigstore_client_id: trusted-artifact-signer
-issuer_url: https://keycloak-keycloak-system.apps.platform-sts.pcbk.p1.openshiftapps.com/auth/realms/trusted-artifact-signer
-oidc_issuers_type: email
+tas_single_node_oidc_issuers: https://keycloak-keycloak-system.apps.platform-sts.pcbk.p1.openshiftapps.com/auth/realms/trusted-artifact-signer
+tas_single_node_oidc_client_id: trusted-artifact-signer
+tas_single_node_issuer_url: https://keycloak-keycloak-system.apps.platform-sts.pcbk.p1.openshiftapps.com/auth/realms/trusted-artifact-signer
+tas_single_node_oidc_issuers_type: email
 
-# Sigstore Images
-fulcio_server_image: quay.io/redhat-user-workloads/rhtas-tenant/fulcio/fulcio-server@sha256:f333772eb0cd23360516da4a7a50813a59d67c690c2b6baef4bc4b6094d1116b
-trillian_log_server_image: quay.io/redhat-user-workloads/rhtas-tenant/trillian/logserver@sha256:cdb2fa8ef85a9727c2b306652e4127ee4b2723cd361a04f364f4a96d60194777
-trillian_logsigner_image: quay.io/redhat-user-workloads/rhtas-tenant/trillian/logsigner@sha256:f8199e0b14f391574181a3e38659a2ec5baeb65ba5101ac63b5b9785ae01c214
-rekor_image: quay.io/redhat-user-workloads/rhtas-tenant/rekor/rekor-server@sha256:a2075576589bec3c4544db4368732cb1388e8f5a3cb2a739d943cee601e64b74
-ct_server_image:
+# RHTAS Images
+tas_single_node_fulcio_server_image:
+  quay.io/redhat-user-workloads/rhtas-tenant/fulcio/fulcio-server@sha256:f333772eb0cd23360516da4a7a50813a59d67c690c2b6baef4bc4b6094d1116b
+tas_single_node_trillian_log_server_image:
+  quay.io/redhat-user-workloads/rhtas-tenant/trillian/logserver@sha256:cdb2fa8ef85a9727c2b306652e4127ee4b2723cd361a04f364f4a96d60194777
+tas_single_node_trillian_logsigner_image:
+  quay.io/redhat-user-workloads/rhtas-tenant/trillian/logsigner@sha256:f8199e0b14f391574181a3e38659a2ec5baeb65ba5101ac63b5b9785ae01c214
+tas_single_node_rekor_image:
+  quay.io/redhat-user-workloads/rhtas-tenant/rekor/rekor-server@sha256:a2075576589bec3c4544db4368732cb1388e8f5a3cb2a739d943cee601e64b74
+tas_single_node_ct_server_image:
   quay.io/redhat-user-workloads/rhtas-tenant/certificate-transparency-go/certificate-transparency-go@sha256:1419a048cb5095b3f65d08224e6f94c6eb166d8d5a16707942aed2880992ddee
 
 # Supplement images
-redis_image: quay.io/redhat-user-workloads/rhtas-tenant/trillian/redis@sha256:0804a6634b8836cb2e957ee16d54e8d6ab94d311362a48baf238b1f575d79934
-trillian_db_image: quay.io/redhat-user-workloads/rhtas-tenant/trillian/database@sha256:145560da2f030ab6574d62c912b757d5537e75e4ec10e0d26cf56a67b1573969
-tuf_image: quay.io/securesign/tuf/server:latest
-netcat_image: registry.redhat.io/openshift4/ose-tools-rhel8@sha256:486b4d2dd0d10c5ef0212714c94334e04fe8a3d36cf619881986201a50f123c7
-nginx_image: registry.redhat.io/rhel8/nginx-122@sha256:088912945049dbb83bc2e8a70732059e4baca7462447c738f4a9ab34ecc705da
-curl_image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+tas_single_node_redis_image: quay.io/redhat-user-workloads/rhtas-tenant/trillian/redis@sha256:0804a6634b8836cb2e957ee16d54e8d6ab94d311362a48baf238b1f575d79934
+tas_single_node_trillian_db_image:
+  quay.io/redhat-user-workloads/rhtas-tenant/trillian/database@sha256:145560da2f030ab6574d62c912b757d5537e75e4ec10e0d26cf56a67b1573969
+tas_single_node_tuf_image: quay.io/securesign/tuf/server:latest
+tas_single_node_netcat_image: registry.redhat.io/openshift4/ose-tools-rhel8@sha256:486b4d2dd0d10c5ef0212714c94334e04fe8a3d36cf619881986201a50f123c7
+tas_single_node_nginx_image: registry.redhat.io/rhel8/nginx-122@sha256:088912945049dbb83bc2e8a70732059e4baca7462447c738f4a9ab34ecc705da
+tas_single_node_curl_image: registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/roles/tas_single_node/handlers/main.yml
+++ b/roles/tas_single_node/handlers/main.yml
@@ -1,2 +1,2 @@
 ---
-# handlers file for sigstore_scaffolding
+# handlers file for tas_single_node

--- a/roles/tas_single_node/meta/main.yml
+++ b/roles/tas_single_node/meta/main.yml
@@ -53,6 +53,5 @@ dependencies: []
 # if you add dependencies to this list.
 
 collections:
-  - fedora.linux_system_roles
   - containers.podman
   - community.crypto

--- a/roles/tas_single_node/meta/main.yml
+++ b/roles/tas_single_node/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  author: your name
-  description: your role description
-  company: your company (optional)
+  author: Red Hat
+  description: Install RHTAS on a single node
+  company: Red Hat
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,9 +15,9 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
+  license: Apache-2.0
 
-  min_ansible_version: 2.1
+  min_ansible_version: "2.16"
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/roles/tas_single_node/meta/main.yml
+++ b/roles/tas_single_node/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   author: your name
   description: your role description
@@ -40,16 +41,16 @@ galaxy_info:
   #   - 99.99
 
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
+# List tags for your role here, one per line. A tag is a keyword that describes
+# and categorizes the role. Users find roles by searching for tags. Be sure to
+# remove the '[]' above, if you add tags to this list.
+#
+# NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+#       Maximum 20 tags per role.
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
 
 collections:
   - fedora.linux_system_roles

--- a/roles/tas_single_node/tasks/certificates.yml
+++ b/roles/tas_single_node/tasks/certificates.yml
@@ -2,45 +2,45 @@
 - name: Confirmed required parameters provided
   ansible.builtin.assert:
     that:
-      - base_hostname is defined
-      - base_hostname | trim | length > 0
-    msg: "'base_hostname' must be specified"
+      - tas_single_node_base_hostname is defined
+      - tas_single_node_base_hostname | trim | length > 0
+    msg: "'tas_single_node_base_hostname' must be specified"
 
 - name: Create Certificates Directory
   become: true
   ansible.builtin.file:
     state: directory
-    dest: "{{ certs_dir }}"
+    dest: "{{ tas_single_node_certs_dir }}"
     mode: "0600"
 
 - name: List files in certs directory
   become: true
   ansible.builtin.find:
     file_type: file
-    paths: "{{ certs_dir }}"
+    paths: "{{ tas_single_node_certs_dir }}"
   register: certs_dir_files
 
 - name: Create Local Certificates Directory
   ansible.builtin.file:
     state: directory
-    dest: "{{ local_certs_dir }}"
+    dest: "{{ tas_single_node_local_certs_dir }}"
     mode: "0600"
   delegate_to: localhost
 
 - name: Create private key (RSA, 4096 bits)
   community.crypto.openssl_privatekey:
-    path: "{{ local_sigstore_private_key }}"
+    path: "{{ tas_single_node_local_private_key }}"
   delegate_to: localhost
-  when: (certs_dir_files.files | selectattr('path', 'equalto', remote_sigstore_private_key) | list | length) == 0
+  when: (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_private_key) | list | length) == 0
 
 - name: Create Root CA
   delegate_to: localhost
-  when: (certs_dir_files.files | selectattr('path', 'equalto', remote_sigstore_ca) | list | length) == 0
+  when: (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_ca) | list | length) == 0
   block:
     - name: Create certificate signing request (CSR) for CA certificate
       community.crypto.openssl_csr_pipe:
-        privatekey_path: "{{ local_sigstore_private_key }}"
-        common_name: "{{ base_hostname }}"
+        privatekey_path: "{{ tas_single_node_local_private_key }}"
+        common_name: "{{ tas_single_node_base_hostname }}"
         use_common_name_for_san: false
         basic_constraints:
           - CA:TRUE
@@ -52,9 +52,9 @@
 
     - name: Create self-signed CA certificate from CSR
       community.crypto.x509_certificate:
-        path: "{{ local_sigstore_ca }}"
+        path: "{{ tas_single_node_local_ca }}"
         csr_content: "{{ ca_csr.csr }}"
-        privatekey_path: "{{ local_sigstore_private_key }}"
+        privatekey_path: "{{ tas_single_node_local_private_key }}"
         provider: selfsigned
         selfsigned_not_after: +365d # valid for one year
 
@@ -68,38 +68,38 @@
     loop_var: cert_name
   vars:
     existing_files: "{{ certs_dir_files }}"
-    local_ca_key_path: "{{ local_sigstore_private_key }}"
-    local_ca_cert_path: "{{ local_sigstore_ca }}"
-    remote_ca_key_path: "{{ remote_sigstore_private_key }}"
-    remote_ca_cert_path: "{{ remote_sigstore_ca }}"
-    dns_name: "{{ cert_name }}.{{ base_hostname }}"
+    local_ca_key_path: "{{ tas_single_node_local_private_key }}"
+    local_ca_cert_path: "{{ tas_single_node_local_ca }}"
+    remote_ca_key_path: "{{ tas_single_node_remote_private_key }}"
+    remote_ca_cert_path: "{{ tas_single_node_remote_ca }}"
+    dns_name: "{{ cert_name }}.{{ tas_single_node_base_hostname }}"
 
 - name: Create fulcio root
   delegate_to: localhost
   when: >
-    (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_private_key) | list | length) == 0
-    or (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_public_key) | list | length) == 0
-    or (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_root_ca) | list | length) == 0
+    (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_fulcio_private_key) | list | length) == 0
+    or (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_fulcio_public_key) | list | length) == 0
+    or (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | length) == 0
 
   block:
     - name: Create Fulcio Private Key
       community.crypto.openssl_privatekey:
-        path: "{{ local_fulcio_private_key }}"
+        path: "{{ tas_single_node_local_fulcio_private_key }}"
         curve: secp256r1
         type: ECC
-        passphrase: "{{ fulcio_ca_passphrase }}"
+        passphrase: "{{ tas_single_node_fulcio_ca_passphrase }}"
         cipher: auto
 
     - name: Create Fulcio Public Key
       community.crypto.openssl_publickey:
-        path: "{{ local_fulcio_public_key }}"
-        privatekey_path: "{{ local_fulcio_private_key }}"
-        privatekey_passphrase: "{{ fulcio_ca_passphrase }}"
+        path: "{{ tas_single_node_local_fulcio_public_key }}"
+        privatekey_path: "{{ tas_single_node_local_fulcio_private_key }}"
+        privatekey_passphrase: "{{ tas_single_node_fulcio_ca_passphrase }}"
 
     - name: Create certificate signing request (CSR) for Fulcio Root certificate
       community.crypto.openssl_csr_pipe:
-        privatekey_path: "{{ local_fulcio_private_key }}"
-        privatekey_passphrase: "{{ fulcio_ca_passphrase }}"
+        privatekey_path: "{{ tas_single_node_local_fulcio_private_key }}"
+        privatekey_passphrase: "{{ tas_single_node_fulcio_ca_passphrase }}"
         basic_constraints:
           - CA:TRUE
         basic_constraints_critical: true
@@ -110,42 +110,42 @@
 
     - name: Create self-signed Fulcio root from CSR
       community.crypto.x509_certificate:
-        path: "{{ local_fulcio_root_ca }}"
+        path: "{{ tas_single_node_local_fulcio_root_ca }}"
         csr_content: "{{ fulcio_root_csr.csr }}"
-        privatekey_path: "{{ local_fulcio_private_key }}"
-        privatekey_passphrase: "{{ fulcio_ca_passphrase }}"
+        privatekey_path: "{{ tas_single_node_local_fulcio_private_key }}"
+        privatekey_passphrase: "{{ tas_single_node_fulcio_ca_passphrase }}"
         provider: selfsigned
 
 - name: Create ctlog root
   delegate_to: localhost
   when: >
-    (certs_dir_files.files | selectattr('path', 'equalto', remote_ctlog_private_key) | list | length) == 0
-    or (certs_dir_files.files | selectattr('path', 'equalto', remote_ctlog_public_key) | list | length) == 0
+    (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_ctlog_private_key) | list | length) == 0
+    or (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_ctlog_public_key) | list | length) == 0
 
   block:
     - name: Create ctlog Private Key
       community.crypto.openssl_privatekey:
-        path: "{{ local_ctlog_private_key }}"
+        path: "{{ tas_single_node_local_ctlog_private_key }}"
         curve: secp256r1
         type: ECC
-        passphrase: "{{ ctlog_ca_passphrase }}"
+        passphrase: "{{ tas_single_node_ctlog_ca_passphrase }}"
         cipher: auto
     - name: Create ctlog Public Key
       community.crypto.openssl_publickey:
-        path: "{{ local_ctlog_public_key }}"
-        privatekey_path: "{{ local_ctlog_private_key }}"
-        privatekey_passphrase: "{{ ctlog_ca_passphrase }}"
+        path: "{{ tas_single_node_local_ctlog_public_key }}"
+        privatekey_path: "{{ tas_single_node_local_ctlog_private_key }}"
+        privatekey_passphrase: "{{ tas_single_node_ctlog_ca_passphrase }}"
 
 - name: Copy Certificates to Server
   become: true
   ansible.builtin.copy:
-    src: "{{ local_certs_dir }}/"
-    dest: "{{ certs_dir }}"
+    src: "{{ tas_single_node_local_certs_dir }}/"
+    dest: "{{ tas_single_node_certs_dir }}"
     force: true
     mode: "0600"
 
 - name: Remove Local Certificate Directory
   ansible.builtin.file:
     state: absent
-    dest: "{{ local_certs_dir }}"
+    dest: "{{ tas_single_node_local_certs_dir }}"
   delegate_to: localhost

--- a/roles/tas_single_node/tasks/certificates.yml
+++ b/roles/tas_single_node/tasks/certificates.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Confirmed required parameters provided
   ansible.builtin.assert:
     that:
@@ -8,13 +7,13 @@
     msg: "'base_hostname' must be specified"
 
 - name: Create Certificates Directory
-  become: yes
+  become: true
   ansible.builtin.file:
     state: directory
     dest: "{{ certs_dir }}"
 
 - name: List files in certs directory
-  become: yes
+  become: true
   ansible.builtin.find:
     file_type: file
     paths: "{{ certs_dir }}"
@@ -33,32 +32,32 @@
   when: (certs_dir_files.files | selectattr('path', 'equalto', remote_sigstore_private_key) | list | length) == 0
 
 - name: Create Root CA
-  block:
-  - name: Create certificate signing request (CSR) for CA certificate
-    community.crypto.openssl_csr_pipe:
-      privatekey_path: "{{ local_sigstore_private_key }}"
-      common_name: "{{ base_hostname }}"
-      use_common_name_for_san: false
-      basic_constraints:
-        - 'CA:TRUE'
-      basic_constraints_critical: true
-      key_usage:
-        - keyCertSign
-      key_usage_critical: true
-    register: ca_csr
-
-  - name: Create self-signed CA certificate from CSR
-    community.crypto.x509_certificate:
-      path: "{{ local_sigstore_ca }}"
-      csr_content: "{{ ca_csr.csr }}"
-      privatekey_path: "{{ local_sigstore_private_key }}"
-      provider: selfsigned
-      selfsigned_not_after: +365d  # valid for one year
   delegate_to: localhost
   when: (certs_dir_files.files | selectattr('path', 'equalto', remote_sigstore_ca) | list | length) == 0
+  block:
+    - name: Create certificate signing request (CSR) for CA certificate
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: "{{ local_sigstore_private_key }}"
+        common_name: "{{ base_hostname }}"
+        use_common_name_for_san: false
+        basic_constraints:
+          - CA:TRUE
+        basic_constraints_critical: true
+        key_usage:
+          - keyCertSign
+        key_usage_critical: true
+      register: ca_csr
+
+    - name: Create self-signed CA certificate from CSR
+      community.crypto.x509_certificate:
+        path: "{{ local_sigstore_ca }}"
+        csr_content: "{{ ca_csr.csr }}"
+        privatekey_path: "{{ local_sigstore_private_key }}"
+        provider: selfsigned
+        selfsigned_not_after: +365d # valid for one year
 
 - name: Create Ingress Certificates
-  include_tasks: create_ingress_cert.yml
+  ansible.builtin.include_tasks: create_ingress_cert.yml
   loop:
     - fulcio
     - rekor
@@ -67,13 +66,17 @@
     loop_var: cert_name
   vars:
     existing_files: "{{ certs_dir_files }}"
-    local_ca_key_path: "{{ local_sigstore_private_key  }}"
+    local_ca_key_path: "{{ local_sigstore_private_key }}"
     local_ca_cert_path: "{{ local_sigstore_ca }}"
-    remote_ca_key_path: "{{ remote_sigstore_private_key  }}"
+    remote_ca_key_path: "{{ remote_sigstore_private_key }}"
     remote_ca_cert_path: "{{ remote_sigstore_ca }}"
     dns_name: "{{ cert_name }}.{{ base_hostname }}"
 
 - name: Create fulcio root
+  delegate_to: localhost
+  when: (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_private_key) | list | length) == 0 or (certs_dir_files.files | selectattr('path', 'equalto',
+    remote_fulcio_public_key) | list | length) == 0 or (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_root_ca) | list | length) == 0
+
   block:
     - name: Create Fulcio Private Key
       community.crypto.openssl_privatekey:
@@ -82,10 +85,11 @@
         type: ECC
         passphrase: "{{ fulcio_ca_passphrase }}"
         cipher: auto
+
     - name: Create Fulcio Public Key
       community.crypto.openssl_publickey:
         path: "{{ local_fulcio_public_key }}"
-        privatekey_path : "{{ local_fulcio_private_key }}"
+        privatekey_path: "{{ local_fulcio_private_key }}"
         privatekey_passphrase: "{{ fulcio_ca_passphrase }}"
 
     - name: Create certificate signing request (CSR) for Fulcio Root certificate
@@ -93,7 +97,7 @@
         privatekey_path: "{{ local_fulcio_private_key }}"
         privatekey_passphrase: "{{ fulcio_ca_passphrase }}"
         basic_constraints:
-          - 'CA:TRUE'
+          - CA:TRUE
         basic_constraints_critical: true
         key_usage:
           - keyCertSign
@@ -107,10 +111,12 @@
         privatekey_path: "{{ local_fulcio_private_key }}"
         privatekey_passphrase: "{{ fulcio_ca_passphrase }}"
         provider: selfsigned
-  delegate_to: localhost
-  when: (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_private_key) | list | length) == 0 or (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_public_key) | list | length) == 0 or (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_root_ca) | list | length) == 0
 
 - name: Create ctlog root
+  delegate_to: localhost
+  when: (certs_dir_files.files | selectattr('path', 'equalto', remote_ctlog_private_key) | list | length) == 0 or (certs_dir_files.files | selectattr('path', 'equalto',
+    remote_ctlog_public_key) | list | length) == 0
+
   block:
     - name: Create ctlog Private Key
       community.crypto.openssl_privatekey:
@@ -122,15 +128,11 @@
     - name: Create ctlog Public Key
       community.crypto.openssl_publickey:
         path: "{{ local_ctlog_public_key }}"
-        privatekey_path : "{{ local_ctlog_private_key }}"
+        privatekey_path: "{{ local_ctlog_private_key }}"
         privatekey_passphrase: "{{ ctlog_ca_passphrase }}"
 
-  delegate_to: localhost
-  when: (certs_dir_files.files | selectattr('path', 'equalto', remote_ctlog_private_key) | list | length) == 0 or (certs_dir_files.files | selectattr('path', 'equalto', remote_ctlog_public_key) | list | length) == 0
-
-
 - name: Copy Certificates to Server
-  become: yes
+  become: true
   ansible.builtin.copy:
     src: "{{ local_certs_dir }}/"
     dest: "{{ certs_dir }}"

--- a/roles/tas_single_node/tasks/certificates.yml
+++ b/roles/tas_single_node/tasks/certificates.yml
@@ -11,7 +11,7 @@
   ansible.builtin.file:
     state: directory
     dest: "{{ tas_single_node_certs_dir }}"
-    mode: "0600"
+    mode: "0700"
 
 - name: List files in certs directory
   become: true
@@ -24,7 +24,7 @@
   ansible.builtin.file:
     state: directory
     dest: "{{ tas_single_node_local_certs_dir }}"
-    mode: "0600"
+    mode: "0700"
   delegate_to: localhost
 
 - name: Create private key (RSA, 4096 bits)

--- a/roles/tas_single_node/tasks/certificates.yml
+++ b/roles/tas_single_node/tasks/certificates.yml
@@ -11,6 +11,7 @@
   ansible.builtin.file:
     state: directory
     dest: "{{ certs_dir }}"
+    mode: "0600"
 
 - name: List files in certs directory
   become: true
@@ -23,6 +24,7 @@
   ansible.builtin.file:
     state: directory
     dest: "{{ local_certs_dir }}"
+    mode: "0600"
   delegate_to: localhost
 
 - name: Create private key (RSA, 4096 bits)
@@ -74,8 +76,10 @@
 
 - name: Create fulcio root
   delegate_to: localhost
-  when: (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_private_key) | list | length) == 0 or (certs_dir_files.files | selectattr('path', 'equalto',
-    remote_fulcio_public_key) | list | length) == 0 or (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_root_ca) | list | length) == 0
+  when: >
+    (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_private_key) | list | length) == 0
+    or (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_public_key) | list | length) == 0
+    or (certs_dir_files.files | selectattr('path', 'equalto', remote_fulcio_root_ca) | list | length) == 0
 
   block:
     - name: Create Fulcio Private Key
@@ -114,8 +118,9 @@
 
 - name: Create ctlog root
   delegate_to: localhost
-  when: (certs_dir_files.files | selectattr('path', 'equalto', remote_ctlog_private_key) | list | length) == 0 or (certs_dir_files.files | selectattr('path', 'equalto',
-    remote_ctlog_public_key) | list | length) == 0
+  when: >
+    (certs_dir_files.files | selectattr('path', 'equalto', remote_ctlog_private_key) | list | length) == 0
+    or (certs_dir_files.files | selectattr('path', 'equalto', remote_ctlog_public_key) | list | length) == 0
 
   block:
     - name: Create ctlog Private Key
@@ -137,6 +142,7 @@
     src: "{{ local_certs_dir }}/"
     dest: "{{ certs_dir }}"
     force: true
+    mode: "0600"
 
 - name: Remove Local Certificate Directory
   ansible.builtin.file:

--- a/roles/tas_single_node/tasks/create_ingress_cert.yml
+++ b/roles/tas_single_node/tasks/create_ingress_cert.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Set Certificate Facts
   ansible.builtin.set_fact:
     local_key_path: "{{ local_certs_dir }}/ingress-{{ cert_name }}.key"
@@ -9,45 +8,46 @@
   delegate_to: localhost
 
 - name: Create Certificate and Private Key
-  block:
-  - name: Create {{ cert_name }} Private Key
-    community.crypto.openssl_privatekey:
-      path: "{{ local_key_path }}"
-
-  # TODO: Allow more parameters to be provided
-  - name: Create certificate signing request (CSR) for new certificate
-    community.crypto.openssl_csr_pipe:
-      privatekey_path: "{{ local_key_path }}"
-      subject:
-        commonName: "{{ dns_name }}"
-      basic_constraints:
-        - 'CA:FALSE'
-      extended_key_usage:
-        - serverAuth
-      key_usage:
-        - digitalSignature
-        - nonRepudiation
-        - keyEncipherment
-        - dataEncipherment
-      subject_alt_name:
-        - "DNS:{{ dns_name }}"
-    register: csr
-
-  - name: Sign certificate with our CA
-    community.crypto.x509_certificate_pipe:
-      csr_content: "{{ csr.csr }}"
-      provider: ownca
-      ownca_path: "{{ local_ca_cert_path }}"
-      ownca_privatekey_path: "{{ local_ca_key_path }}"
-      # ownca_privatekey_passphrase: "{{ secret_ca_passphrase }}"
-      ownca_not_after: +365d  # valid for one year
-    register: certificate
-  
-  - name: Create certificate
-    copy:
-      dest: "{{ local_cert_path }}"
-      content: "{{ certificate.certificate }}"
-    when: certificate is changed
   delegate_to: localhost
-  when: (existing_files.files | selectattr('path', 'equalto', remote_key_path) | list | length) == 0 or (existing_files.files | selectattr('path', 'equalto', remote_cert_path) | list | length) == 0
-#   when: ((existing_files.files | selectattr('path', 'equalto', key_path) | list | length) == 0) and (existing_files.files | selectattr('path', 'equalto', cert_path) | list | length) == 0))
+  when: (existing_files.files | selectattr('path', 'equalto', remote_key_path) | list | length) == 0 or (existing_files.files | selectattr('path', 'equalto', remote_cert_path)
+    | list | length) == 0
+  #   when: ((existing_files.files | selectattr('path', 'equalto', key_path) | list | length) == 0) and (existing_files.files | selectattr('path', 'equalto', cert_path) | list | length) == 0))
+  block:
+    - name: Create {{ cert_name }} Private Key
+      community.crypto.openssl_privatekey:
+        path: "{{ local_key_path }}"
+
+    # TODO: Allow more parameters to be provided
+    - name: Create certificate signing request (CSR) for new certificate
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: "{{ local_key_path }}"
+        subject:
+          commonName: "{{ dns_name }}"
+        basic_constraints:
+          - CA:FALSE
+        extended_key_usage:
+          - serverAuth
+        key_usage:
+          - digitalSignature
+          - nonRepudiation
+          - keyEncipherment
+          - dataEncipherment
+        subject_alt_name:
+          - DNS:{{ dns_name }}
+      register: csr
+
+    - name: Sign certificate with our CA
+      community.crypto.x509_certificate_pipe:
+        csr_content: "{{ csr.csr }}"
+        provider: ownca
+        ownca_path: "{{ local_ca_cert_path }}"
+        ownca_privatekey_path: "{{ local_ca_key_path }}"
+        # ownca_privatekey_passphrase: "{{ secret_ca_passphrase }}"
+        ownca_not_after: +365d # valid for one year
+      register: certificate
+
+    - name: Create certificate
+      ansible.builtin.copy:
+        dest: "{{ local_cert_path }}"
+        content: "{{ certificate.certificate }}"
+      when: certificate is changed

--- a/roles/tas_single_node/tasks/create_ingress_cert.yml
+++ b/roles/tas_single_node/tasks/create_ingress_cert.yml
@@ -53,4 +53,4 @@
         dest: "{{ local_cert_path }}"
         content: "{{ certificate.certificate }}"
         mode: "0600"
-      when: certificate is changed
+      when: certificate is changed  # noqa no-handler

--- a/roles/tas_single_node/tasks/create_ingress_cert.yml
+++ b/roles/tas_single_node/tasks/create_ingress_cert.yml
@@ -1,10 +1,10 @@
 ---
 - name: Set Certificate Facts
   ansible.builtin.set_fact:
-    local_key_path: "{{ local_certs_dir }}/ingress-{{ cert_name }}.key"
-    local_cert_path: "{{ local_certs_dir }}/ingress-{{ cert_name }}.pem"
-    remote_key_path: "{{ certs_dir }}/ingress-{{ cert_name }}.key"
-    remote_cert_path: "{{ certs_dir }}/ingress-{{ cert_name }}.pem"
+    local_key_path: "{{ tas_single_node_local_certs_dir }}/ingress-{{ cert_name }}.key"
+    local_cert_path: "{{ tas_single_node_local_certs_dir }}/ingress-{{ cert_name }}.pem"
+    remote_key_path: "{{ tas_single_node_certs_dir }}/ingress-{{ cert_name }}.key"
+    remote_cert_path: "{{ tas_single_node_certs_dir }}/ingress-{{ cert_name }}.pem"
   delegate_to: localhost
 
 - name: Create Certificate and Private Key

--- a/roles/tas_single_node/tasks/create_ingress_cert.yml
+++ b/roles/tas_single_node/tasks/create_ingress_cert.yml
@@ -9,11 +9,13 @@
 
 - name: Create Certificate and Private Key
   delegate_to: localhost
-  when: (existing_files.files | selectattr('path', 'equalto', remote_key_path) | list | length) == 0 or (existing_files.files | selectattr('path', 'equalto', remote_cert_path)
-    | list | length) == 0
-  #   when: ((existing_files.files | selectattr('path', 'equalto', key_path) | list | length) == 0) and (existing_files.files | selectattr('path', 'equalto', cert_path) | list | length) == 0))
+  when: >
+    (existing_files.files | selectattr('path', 'equalto', remote_key_path) | list | length) == 0
+    or (existing_files.files | selectattr('path', 'equalto', remote_cert_path) | list | length) == 0
+  #   when: ((existing_files.files | selectattr('path', 'equalto', key_path) | list | length) == 0)
+  #         and (existing_files.files | selectattr('path', 'equalto', cert_path) | list | length) == 0))
   block:
-    - name: Create {{ cert_name }} Private Key
+    - name: Create Private Key {{ cert_name }}
       community.crypto.openssl_privatekey:
         path: "{{ local_key_path }}"
 
@@ -50,4 +52,5 @@
       ansible.builtin.copy:
         dest: "{{ local_cert_path }}"
         content: "{{ certificate.certificate }}"
+        mode: "0600"
       when: certificate is changed

--- a/roles/tas_single_node/tasks/main.yml
+++ b/roles/tas_single_node/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install Operating System Components
   ansible.builtin.include_tasks: os.yml
   args:

--- a/roles/tas_single_node/tasks/main.yml
+++ b/roles/tas_single_node/tasks/main.yml
@@ -4,7 +4,7 @@
   args:
     apply:
       become: true
-  when: not skip_os_install
+  when: not tas_single_node_skip_os_install
 
 - name: Create Certificates
   ansible.builtin.include_tasks: certificates.yml

--- a/roles/tas_single_node/tasks/os.yml
+++ b/roles/tas_single_node/tasks/os.yml
@@ -1,14 +1,14 @@
 ---
 - name: Install System Packages dependencies
   ansible.builtin.package:
-    name: "{{ system_packages }}"
+    name: "{{ tas_single_node_system_packages }}"
 
 - name: Install Cockpit
   ansible.builtin.include_role:
     name: cockpit
   vars:
-    cockpit_packages: "{{ cockpit.cockpit_packages }}"
-    cockpit_manage_firewall: "{{ cockpit.cockpit_manage_firewall }}"
+    cockpit_packages: "{{ tas_single_node_cockpit.cockpit_packages }}"
+    cockpit_manage_firewall: "{{ tas_single_node_cockpit.cockpit_manage_firewall }}"
   when: cockpit.enabled | bool
 
 - name: Configure /etc/hosts DNS block
@@ -19,4 +19,4 @@
     create: true
     mode: "0644"
     marker: "# {mark} ANSIBLE MANAGED INGRESS BLOCK"
-  when: setup_host_dns | bool
+  when: tas_single_node_setup_host_dns | bool

--- a/roles/tas_single_node/tasks/os.yml
+++ b/roles/tas_single_node/tasks/os.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install System Packages dependencies
   ansible.builtin.package:
     name: "{{ system_packages }}"
@@ -13,10 +12,10 @@
   when: cockpit.enabled | bool
 
 - name: Configure /etc/hosts DNS block
-  blockinfile:
+  ansible.builtin.blockinfile:
     dest: /etc/hosts
     content: "{{ lookup('template', 'configs/etc-hosts.j2') }}"
     state: present
-    create: yes
+    create: true
     marker: "# {mark} ANSIBLE MANAGED INGRESS BLOCK"
   when: setup_host_dns | bool

--- a/roles/tas_single_node/tasks/os.yml
+++ b/roles/tas_single_node/tasks/os.yml
@@ -14,7 +14,7 @@
 - name: Configure /etc/hosts DNS block
   ansible.builtin.blockinfile:
     dest: /etc/hosts
-    content: "{{ lookup('template', 'configs/etc-hosts.j2') }}"
+    content: "{{ lookup('ansible.builtin.template', 'configs/etc-hosts.j2') }}"
     state: present
     create: true
     mode: "0644"

--- a/roles/tas_single_node/tasks/os.yml
+++ b/roles/tas_single_node/tasks/os.yml
@@ -17,5 +17,6 @@
     content: "{{ lookup('template', 'configs/etc-hosts.j2') }}"
     state: present
     create: true
+    mode: "0644"
     marker: "# {mark} ANSIBLE MANAGED INGRESS BLOCK"
   when: setup_host_dns | bool

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create sigstore network
   containers.podman.podman_network:
     name: "{{ sigstore_podman_network }}"
@@ -12,7 +11,7 @@
     - "{{ kube_manifest_dir }}"
     - "{{ kube_configmap_dir }}"
 
-- name: podman login to registry.redhat.io
+- name: Podman login to registry.redhat.io
   ansible.builtin.command: podman login registry.redhat.io -u '{{ registry_username }}' --password {{ registry_password }}
 
 - name: Configure/Deploy nginx

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -7,12 +7,15 @@
   ansible.builtin.file:
     state: directory
     dest: "{{ item }}"
+    mode: "0600"
   loop:
     - "{{ kube_manifest_dir }}"
     - "{{ kube_configmap_dir }}"
 
 - name: Podman login to registry.redhat.io
   ansible.builtin.command: podman login registry.redhat.io -u '{{ registry_username }}' --password {{ registry_password }}
+  register: podman_login_result
+  changed_when: '"Already logged in" not in podman_login_result'
 
 - name: Configure/Deploy nginx
   ansible.builtin.include_tasks: podman/nginx.yml

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -7,7 +7,7 @@
   ansible.builtin.file:
     state: directory
     dest: "{{ item }}"
-    mode: "0600"
+    mode: "0700"
   loop:
     - "{{ tas_single_node_kube_manifest_dir }}"
     - "{{ tas_single_node_kube_configmap_dir }}"
@@ -16,6 +16,22 @@
   ansible.builtin.command: podman login registry.redhat.io -u '{{ tas_single_node_registry_username }}' --password {{ tas_single_node_registry_password }}
   register: podman_login_result
   changed_when: '"Already logged in" not in podman_login_result'
+
+- name: Pull all images
+  containers.podman.podman_image:
+    name: "{{ item }}"
+  loop:
+    - "{{ tas_single_node_fulcio_server_image }}"
+    - "{{ tas_single_node_trillian_log_server_image }}"
+    - "{{ tas_single_node_trillian_logsigner_image }}"
+    - "{{ tas_single_node_rekor_image }}"
+    - "{{ tas_single_node_ct_server_image }}"
+    - "{{ tas_single_node_redis_image }}"
+    - "{{ tas_single_node_trillian_db_image }}"
+    - "{{ tas_single_node_tuf_image }}"
+    - "{{ tas_single_node_netcat_image }}"
+    - "{{ tas_single_node_nginx_image }}"
+    - "{{ tas_single_node_curl_image }}"
 
 - name: Configure/Deploy nginx
   ansible.builtin.include_tasks: podman/nginx.yml

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -1,7 +1,7 @@
 ---
-- name: Create sigstore network
+- name: Create RHTAS network
   containers.podman.podman_network:
-    name: "{{ sigstore_podman_network }}"
+    name: "{{ tas_single_node_podman_network }}"
 
 - name: Create Manifests/Configs Directory
   ansible.builtin.file:
@@ -9,11 +9,11 @@
     dest: "{{ item }}"
     mode: "0600"
   loop:
-    - "{{ kube_manifest_dir }}"
-    - "{{ kube_configmap_dir }}"
+    - "{{ tas_single_node_kube_manifest_dir }}"
+    - "{{ tas_single_node_kube_configmap_dir }}"
 
 - name: Podman login to registry.redhat.io
-  ansible.builtin.command: podman login registry.redhat.io -u '{{ registry_username }}' --password {{ registry_password }}
+  ansible.builtin.command: podman login registry.redhat.io -u '{{ tas_single_node_registry_username }}' --password {{ tas_single_node_registry_password }}
   register: podman_login_result
   changed_when: '"Already logged in" not in podman_login_result'
 
@@ -22,24 +22,24 @@
 
 - name: Configure/Deploy Trillian
   ansible.builtin.include_tasks: podman/trillian.yml
-  when: trillian_enabled | bool
+  when: tas_single_node_trillian_enabled | bool
 
 - name: Setup Trillian Tree ID
   ansible.builtin.include_tasks: podman/createtree.yml
-  when: trillian_enabled | bool
+  when: tas_single_node_trillian_enabled | bool
 
 - name: Configure/Deploy Rekor
   ansible.builtin.include_tasks: podman/rekor.yml
-  when: rekor_enabled | bool
+  when: tas_single_node_rekor_enabled | bool
 
 - name: Configure/Deploy Fulcio
   ansible.builtin.include_tasks: podman/fulcio.yml
-  when: fulcio_enabled | bool
+  when: tas_single_node_fulcio_enabled | bool
 
 - name: Configure/Deploy ctlog
   ansible.builtin.include_tasks: podman/ctlog.yml
-  when: ctlog_enabled | bool
+  when: tas_single_node_ctlog_enabled | bool
 
 - name: Configure/Deploy tuf
   ansible.builtin.include_tasks: podman/tuf.yml
-  when: tuf_enabled | bool
+  when: tas_single_node_tuf_enabled | bool

--- a/roles/tas_single_node/tasks/podman/createtree.yml
+++ b/roles/tas_single_node/tasks/podman/createtree.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if Trillian treeid Config exists
   ansible.builtin.stat:
-    path: "{{ treeid_config }}"
+    path: "{{ tas_single_node_treeid_config }}"
   register: treeid_config_stat
 
 - name: Obtain existing ctlog ID
@@ -9,7 +9,7 @@
   block:
     - name: Obtain existing Trillian Treeid config
       ansible.builtin.slurp:
-        src: "{{ treeid_config }}"
+        src: "{{ tas_single_node_treeid_config }}"
       register: existing_treeid_config
 
     - name: Set Trillian Tree ID fact
@@ -24,9 +24,9 @@
     - name: Createtree container
       containers.podman.podman_container:
         name: createtree
-        image: "{{ scaffolding_utils_image }}"
+        image: "{{ tas_single_node_scaffolding_utils_image }}"
         command: createtree --admin_server trillian-logserver-pod:8091
-        network: "{{ sigstore_podman_network }}"
+        network: "{{ tas_single_node_podman_network }}"
         detach: false
       register: createtree_container
 
@@ -48,7 +48,7 @@
     - name: Create Trillian treeid ConfigMap
       ansible.builtin.copy:
         content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
-        dest: "{{ treeid_config }}"
+        dest: "{{ tas_single_node_treeid_config }}"
         mode: "0600"
       vars:
         configmap_content:

--- a/roles/tas_single_node/tasks/podman/createtree.yml
+++ b/roles/tas_single_node/tasks/podman/createtree.yml
@@ -1,12 +1,11 @@
 ---
-
 - name: Check if Trillian treeid Config exists
   ansible.builtin.stat:
     path: "{{ treeid_config }}"
   register: treeid_config_stat
 
-
 - name: Obtain existing ctlog ID
+  when: tree_id is not defined and treeid_config_stat.stat.exists
   block:
     - name: Obtain existing Trillian Treeid config
       ansible.builtin.slurp:
@@ -17,13 +16,12 @@
       ansible.builtin.set_fact:
         trillian_tree_id: "{{ (existing_treeid_config.content | b64decode | from_yaml)['data']['tree_id'] }}"
       when: '"tree_id" in (existing_treeid_config.content | b64decode | from_yaml)["data"]'
-  when: tree_id is not defined and treeid_config_stat.stat.exists
-
 
 # Create Tree ID
 - name: Create Tree ID
+  when: trillian_tree_id is not defined or not treeid_config_stat.stat.exists
   block:
-    - name: createtree container
+    - name: Createtree container
       containers.podman.podman_container:
         name: createtree
         image: "{{ scaffolding_utils_image }}"
@@ -59,7 +57,3 @@
             namespace: rekor-system
           data:
             tree_id: "{{ trillian_tree_id }}"
-
-  when: trillian_tree_id is not defined or not treeid_config_stat.stat.exists
-
-

--- a/roles/tas_single_node/tasks/podman/createtree.yml
+++ b/roles/tas_single_node/tasks/podman/createtree.yml
@@ -34,6 +34,7 @@
       ansible.builtin.command:
         cmd: podman logs {{ createtree_container.container.Id }}
       register: createtree_container_logs
+      changed_when: false
 
     - name: Set Trillian tree id
       ansible.builtin.set_fact:
@@ -48,6 +49,7 @@
       ansible.builtin.copy:
         content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
         dest: "{{ treeid_config }}"
+        mode: "0600"
       vars:
         configmap_content:
           kind: ConfigMap

--- a/roles/tas_single_node/tasks/podman/ctlog.yml
+++ b/roles/tas_single_node/tasks/podman/ctlog.yml
@@ -6,15 +6,15 @@
   ansible.builtin.slurp:
     src: "{{ item }}"
   loop:
-    - "{{ remote_ctlog_private_key }}"
-    - "{{ remote_ctlog_public_key }}"
-    - "{{ remote_fulcio_root_ca }}"
+    - "{{ tas_single_node_remote_ctlog_private_key }}"
+    - "{{ tas_single_node_remote_ctlog_public_key }}"
+    - "{{ tas_single_node_remote_fulcio_root_ca }}"
   register: remote_ctlog_certificates
 
 - name: Create ctlog configmap
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
-    dest: "{{ ctlog_configmap_config }}"
+    dest: "{{ tas_single_node_ctlog_configmap_config }}"
     mode: "0600"
   vars:
     configmap_content:
@@ -29,7 +29,7 @@
 - name: Create ctlog Secret
   ansible.builtin.copy:
     content: "{{ secret_content | to_nice_yaml(indent=2) }}"
-    dest: "{{ ctlog_secret }}"
+    dest: "{{ tas_single_node_ctlog_secret }}"
     mode: "0600"
   vars:
     secret_content:
@@ -40,11 +40,11 @@
         namespace: ctlog-system
       data:
         private: |
-          {{ (remote_ctlog_certificates.results | selectattr('source', 'equalto', remote_ctlog_private_key) | list | first).content }}
+          {{ (remote_ctlog_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ctlog_private_key) | list | first).content }}
         public: |
-          {{ (remote_ctlog_certificates.results | selectattr('source', 'equalto', remote_ctlog_public_key) | list | first).content }}
+          {{ (remote_ctlog_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ctlog_public_key) | list | first).content }}
         fulcio-0: |
-          {{ (remote_ctlog_certificates.results | selectattr('source', 'equalto', remote_fulcio_root_ca) | list | first).content }}
+          {{ (remote_ctlog_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}
 
 - name: Deploy ctlog Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -52,7 +52,7 @@
     podman_spec:
       state: started
       systemd_file: ctlog
-      network: "{{ sigstore_podman_network }}"
+      network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/ctlog/ctlog.yaml') | from_yaml }}"
-      configmap: "{{ ctlog_configmap_config }}"
-      secret: "{{ ctlog_secret }}"
+      configmap: "{{ tas_single_node_ctlog_configmap_config }}"
+      secret: "{{ tas_single_node_ctlog_secret }}"

--- a/roles/tas_single_node/tasks/podman/ctlog.yml
+++ b/roles/tas_single_node/tasks/podman/ctlog.yml
@@ -11,6 +11,10 @@
     - "{{ tas_single_node_remote_fulcio_root_ca }}"
   register: remote_ctlog_certificates
 
+- name: Load ctlog config content
+  ansible.builtin.set_fact:
+    ctlog_config_content: "{{ lookup('ansible.builtin.template', 'configs/ctlog-config.j2') }}"
+
 - name: Create ctlog configmap
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
@@ -24,7 +28,7 @@
         name: ctlog-config
         namespace: ctlog-system
       data:
-        config: "{{ lookup('template', 'configs/ctlog-config.j2') }}"
+        config: "{{ ctlog_config_content }}"
 
 - name: Create ctlog Secret
   ansible.builtin.copy:

--- a/roles/tas_single_node/tasks/podman/ctlog.yml
+++ b/roles/tas_single_node/tasks/podman/ctlog.yml
@@ -15,6 +15,7 @@
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
     dest: "{{ ctlog_configmap_config }}"
+    mode: "0600"
   vars:
     configmap_content:
       kind: ConfigMap
@@ -29,6 +30,7 @@
   ansible.builtin.copy:
     content: "{{ secret_content | to_nice_yaml(indent=2) }}"
     dest: "{{ ctlog_secret }}"
+    mode: "0600"
   vars:
     secret_content:
       kind: Secret

--- a/roles/tas_single_node/tasks/podman/ctlog.yml
+++ b/roles/tas_single_node/tasks/podman/ctlog.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Obtain Trillian Tree ID
   ansible.builtin.include_tasks: podman/createtree.yml
 
@@ -49,8 +48,8 @@
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:
     podman_spec:
-      state: "started"
-      systemd_file: "ctlog"
+      state: started
+      systemd_file: ctlog
       network: "{{ sigstore_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/ctlog/ctlog.yaml') | from_yaml }}"
       configmap: "{{ ctlog_configmap_config }}"

--- a/roles/tas_single_node/tasks/podman/fulcio.yml
+++ b/roles/tas_single_node/tasks/podman/fulcio.yml
@@ -2,23 +2,23 @@
 - name: Confirmed required parameters provided
   ansible.builtin.assert:
     that:
-      - base_hostname is defined
-      - base_hostname | trim | length > 0
-    msg: "'base_hostname' must be specified"
+      - tas_single_node_base_hostname is defined
+      - tas_single_node_base_hostname | trim | length > 0
+    msg: "'tas_single_node_base_hostname' must be specified"
 
 - name: Slurp Fulcio Certificates
   ansible.builtin.slurp:
     src: "{{ item }}"
   loop:
-    - "{{ remote_fulcio_private_key }}"
-    - "{{ remote_fulcio_public_key }}"
-    - "{{ remote_fulcio_root_ca }}"
+    - "{{ tas_single_node_remote_fulcio_private_key }}"
+    - "{{ tas_single_node_remote_fulcio_public_key }}"
+    - "{{ tas_single_node_remote_fulcio_root_ca }}"
   register: remote_fulcio_certificates
 
 - name: Create Fulcio Config ConfigMap
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
-    dest: "{{ fulcio_server_config }}"
+    dest: "{{ tas_single_node_fulcio_server_config }}"
     mode: "0600"
   vars:
     configmap_content:
@@ -34,7 +34,7 @@
 - name: Create Fulcio Secret
   ansible.builtin.copy:
     content: "{{ secret_content | to_nice_yaml(indent=2) }}"
-    dest: "{{ fulcio_server_secret_config }}"
+    dest: "{{ tas_single_node_fulcio_server_secret_config }}"
     mode: "0600"
   vars:
     secret_content:
@@ -45,12 +45,12 @@
         namespace: fulcio-system
       data:
         key.pem: |
-          {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', remote_fulcio_private_key) | list | first).content }}
+          {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_private_key) | list | first).content }}
         cert.pem: |
-          {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', remote_fulcio_root_ca) | list | first).content }}
+          {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}
         public: |
-          {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', remote_fulcio_public_key) | list | first).content }}
-        password: "{{ fulcio_ca_passphrase }}"
+          {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_public_key) | list | first).content }}
+        password: "{{ tas_single_node_fulcio_ca_passphrase }}"
 
 - name: Deploy Fulcio Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -58,7 +58,7 @@
     podman_spec:
       state: started
       systemd_file: fulcio
-      network: "{{ sigstore_podman_network }}"
+      network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/fulcio/fulcio-server.yaml') | from_yaml }}"
-      configmap: "{{ fulcio_server_config }}"
-      secret: "{{ fulcio_server_secret_config }}"
+      configmap: "{{ tas_single_node_fulcio_server_config }}"
+      secret: "{{ tas_single_node_fulcio_server_secret_config }}"

--- a/roles/tas_single_node/tasks/podman/fulcio.yml
+++ b/roles/tas_single_node/tasks/podman/fulcio.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Confirmed required parameters provided
   ansible.builtin.assert:
     that:
@@ -44,20 +43,19 @@
         namespace: fulcio-system
       data:
         key.pem: |
-          {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', remote_fulcio_private_key) | list | first).content  }}
+          {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', remote_fulcio_private_key) | list | first).content }}
         cert.pem: |
           {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', remote_fulcio_root_ca) | list | first).content }}
         public: |
           {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', remote_fulcio_public_key) | list | first).content }}
-        password: "{{ fulcio_ca_passphrase  }}"
-
+        password: "{{ fulcio_ca_passphrase }}"
 
 - name: Deploy Fulcio Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:
     podman_spec:
-      state: "started"
-      systemd_file: "fulcio"
+      state: started
+      systemd_file: fulcio
       network: "{{ sigstore_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/fulcio/fulcio-server.yaml') | from_yaml }}"
       configmap: "{{ fulcio_server_config }}"

--- a/roles/tas_single_node/tasks/podman/fulcio.yml
+++ b/roles/tas_single_node/tasks/podman/fulcio.yml
@@ -19,6 +19,7 @@
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
     dest: "{{ fulcio_server_config }}"
+    mode: "0600"
   vars:
     configmap_content:
       kind: ConfigMap
@@ -34,6 +35,7 @@
   ansible.builtin.copy:
     content: "{{ secret_content | to_nice_yaml(indent=2) }}"
     dest: "{{ fulcio_server_secret_config }}"
+    mode: "0600"
   vars:
     secret_content:
       kind: Secret

--- a/roles/tas_single_node/tasks/podman/fulcio.yml
+++ b/roles/tas_single_node/tasks/podman/fulcio.yml
@@ -15,6 +15,10 @@
     - "{{ tas_single_node_remote_fulcio_root_ca }}"
   register: remote_fulcio_certificates
 
+- name: Load Fulcio config content
+  ansible.builtin.set_fact:
+    fulcio_config_content: "{{ lookup('ansible.builtin.template', 'configs/fulcio-oidc.conf.j2') }}"
+
 - name: Create Fulcio Config ConfigMap
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
@@ -29,7 +33,7 @@
         namespace: fulcio-system
       data:
         config.json: |
-          {{ lookup('ansible.builtin.template', 'configs/fulcio-oidc.conf.j2') | to_json }}
+          {{ fulcio_config_content | to_json }}
 
 - name: Create Fulcio Secret
   ansible.builtin.copy:

--- a/roles/tas_single_node/tasks/podman/fulcio.yml
+++ b/roles/tas_single_node/tasks/podman/fulcio.yml
@@ -54,7 +54,7 @@
           {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}
         public: |
           {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_public_key) | list | first).content }}
-        password: "{{ tas_single_node_fulcio_ca_passphrase }}"
+        password: "{{ tas_single_node_fulcio_ca_passphrase | b64encode }}"
 
 - name: Deploy Fulcio Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml

--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -1,15 +1,21 @@
 ---
 - name: Set location of Podman Play Manifest
   ansible.builtin.set_fact:
-    kube_play_file: >
-      "{{ tas_single_node_kube_manifest_dir + '/' + podman_spec.kube_file_content.metadata.namespace + '_'
-      + podman_spec.kube_file_content.metadata.name + '.yml' }}"
+    kube_play_file: >-
+      {{ tas_single_node_kube_manifest_dir + '/' + podman_spec.kube_file_content.metadata.namespace + '_'
+      + podman_spec.kube_file_content.metadata.name + '.yml' }}
 
 - name: Copy Manifest to Server
   ansible.builtin.copy:
     content: "{{ podman_spec.kube_file_content | to_nice_yaml(indent=2) }}"
     dest: "{{ kube_play_file }}"
     mode: "0600"
+
+- name: debug
+  debug:
+    msg: "{{ podman_spec.secret }}"
+  when: podman_spec.secret is defined
+
 
 - name: Create Secret
   containers.podman.podman_play:

--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -11,12 +11,6 @@
     dest: "{{ kube_play_file }}"
     mode: "0600"
 
-- name: debug
-  debug:
-    msg: "{{ podman_spec.secret }}"
-  when: podman_spec.secret is defined
-
-
 - name: Create Secret
   containers.podman.podman_play:
     kube_file: "{{ podman_spec.secret }}"

--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Set location of Podman Play Manifest
   ansible.builtin.set_fact:
     kube_play_file: "{{ kube_manifest_dir + '/' + podman_spec.kube_file_content.metadata.namespace + '_' + podman_spec.kube_file_content.metadata.name + '.yml' }}"
@@ -17,13 +16,13 @@
 
 - name: Copy Systemd file to Server
   ansible.builtin.template:
-    src: "systemd/systemd-cm.j2"
+    src: systemd/systemd-cm.j2
     dest: "{{ systemd_directory + '/' + podman_spec.systemd_file }}.service"
   when: podman_spec.configmap is defined
 
 - name: Copy Systemd file to Server
   ansible.builtin.template:
-    src: "systemd/systemd-nocm.j2"
+    src: systemd/systemd-nocm.j2
     dest: "{{ systemd_directory + '/' + podman_spec.systemd_file }}.service"
   when: podman_spec.configmap is not defined
 

--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -2,7 +2,8 @@
 - name: Set location of Podman Play Manifest
   ansible.builtin.set_fact:
     kube_play_file: >
-      "{{ kube_manifest_dir + '/' + podman_spec.kube_file_content.metadata.namespace + '_' + podman_spec.kube_file_content.metadata.name + '.yml' }}"
+      "{{ tas_single_node_kube_manifest_dir + '/' + podman_spec.kube_file_content.metadata.namespace + '_'
+      + podman_spec.kube_file_content.metadata.name + '.yml' }}"
 
 - name: Copy Manifest to Server
   ansible.builtin.copy:
@@ -19,14 +20,14 @@
 - name: Copy Systemd file to Server
   ansible.builtin.template:
     src: systemd/systemd-cm.j2
-    dest: "{{ systemd_directory + '/' + podman_spec.systemd_file }}.service"
+    dest: "{{ tas_single_node_systemd_directory + '/' + podman_spec.systemd_file }}.service"
     mode: "0600"
   when: podman_spec.configmap is defined
 
 - name: Copy Systemd file to Server
   ansible.builtin.template:
     src: systemd/systemd-nocm.j2
-    dest: "{{ systemd_directory + '/' + podman_spec.systemd_file }}.service"
+    dest: "{{ tas_single_node_systemd_directory + '/' + podman_spec.systemd_file }}.service"
     mode: "0600"
   when: podman_spec.configmap is not defined
 

--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -1,12 +1,14 @@
 ---
 - name: Set location of Podman Play Manifest
   ansible.builtin.set_fact:
-    kube_play_file: "{{ kube_manifest_dir + '/' + podman_spec.kube_file_content.metadata.namespace + '_' + podman_spec.kube_file_content.metadata.name + '.yml' }}"
+    kube_play_file: >
+      "{{ kube_manifest_dir + '/' + podman_spec.kube_file_content.metadata.namespace + '_' + podman_spec.kube_file_content.metadata.name + '.yml' }}"
 
 - name: Copy Manifest to Server
   ansible.builtin.copy:
     content: "{{ podman_spec.kube_file_content | to_nice_yaml(indent=2) }}"
     dest: "{{ kube_play_file }}"
+    mode: "0600"
 
 - name: Create Secret
   containers.podman.podman_play:
@@ -18,12 +20,14 @@
   ansible.builtin.template:
     src: systemd/systemd-cm.j2
     dest: "{{ systemd_directory + '/' + podman_spec.systemd_file }}.service"
+    mode: "0600"
   when: podman_spec.configmap is defined
 
 - name: Copy Systemd file to Server
   ansible.builtin.template:
     src: systemd/systemd-nocm.j2
     dest: "{{ systemd_directory + '/' + podman_spec.systemd_file }}.service"
+    mode: "0600"
   when: podman_spec.configmap is not defined
 
 - name: Start Podman Service

--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -72,8 +72,9 @@
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-rekor.key') | list | first).content }}
         ingress-tuf.key: |
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tuf.key') | list | first).content }}
-        ingress-fulcio.key: |
-          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-fulcio.key') | list | first).content }}
+        ingress-fulcio.key: >
+          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir
+          + '/ingress-fulcio.key') | list | first).content }}
 
 - name: Create nginx config ConfigMap
   ansible.builtin.copy:

--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Confirmed required parameters provided
   ansible.builtin.assert:
     that:
@@ -29,17 +28,20 @@
     - "{{ certs_dir }}/ingress-fulcio.key"
   register: remote_ingress_certificates
 
-- name: base64 encode the rekor ingress
-  set_fact: 
-    rekor_ingress_base64: "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-rekor.pem') | list | first).content | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
+- name: Base64 encode the rekor ingress
+  ansible.builtin.set_fact:
+    rekor_ingress_base64: "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-rekor.pem') | list | first).content | b64decode
+      + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
 
-- name: base64 encode the tuf ingress
-  set_fact: 
-    tuf_ingress_base64: "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-tuf.pem') | list | first).content | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
+- name: Base64 encode the tuf ingress
+  ansible.builtin.set_fact:
+    tuf_ingress_base64: "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-tuf.pem') | list | first).content | b64decode
+      + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
 
-- name: base 64 encode the fulcio ingress
-  set_fact: 
-    fulcio_ingress_base64: "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-fulcio.pem') | list | first).content | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
+- name: Base 64 encode the fulcio ingress
+  ansible.builtin.set_fact:
+    fulcio_ingress_base64: "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-fulcio.pem') | list | first).content |
+      b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
 
 - name: Create nginx certs Secret
   ansible.builtin.copy:
@@ -54,15 +56,15 @@
         namespace: nginx-system
       data:
         ingress-rekor.pem: |
-          {{ rekor_ingress_base64 | b64encode}}
+          {{ rekor_ingress_base64 | b64encode }}
         ingress-tuf.pem: |
-          {{ tuf_ingress_base64 | b64encode}}
+          {{ tuf_ingress_base64 | b64encode }}
         ingress-fulcio.pem: |
-          {{ fulcio_ingress_base64 | b64encode}}
+          {{ fulcio_ingress_base64 | b64encode }}
         ingress-rekor.key: |
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-rekor.key') | list | first).content }}
         ingress-tuf.key: |
-          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-tuf.key') | list | first).content  }}
+          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-tuf.key') | list | first).content }}
         ingress-fulcio.key: |
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-fulcio.key') | list | first).content }}
 
@@ -85,9 +87,9 @@
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:
     podman_spec:
-      state: "started"
+      state: started
       network: "{{ sigstore_podman_network }}"
-      systemd_file: "nginx"
+      systemd_file: nginx
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/nginx/nginx.yaml') | from_yaml }}"
       configmap: "{{ nginx_config }}"
       secret: "{{ nginx_certs_config }}"

--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -30,23 +30,27 @@
 
 - name: Base64 encode the rekor ingress
   ansible.builtin.set_fact:
-    rekor_ingress_base64: "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-rekor.pem') | list | first).content | b64decode
+    rekor_ingress_base64: >
+      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-rekor.pem') | list | first).content | b64decode
       + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
 
 - name: Base64 encode the tuf ingress
   ansible.builtin.set_fact:
-    tuf_ingress_base64: "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-tuf.pem') | list | first).content | b64decode
+    tuf_ingress_base64: >
+      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-tuf.pem') | list | first).content | b64decode
       + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
 
 - name: Base 64 encode the fulcio ingress
   ansible.builtin.set_fact:
-    fulcio_ingress_base64: "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-fulcio.pem') | list | first).content |
-      b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
+    fulcio_ingress_base64: >
+      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-fulcio.pem') | list | first).content | b64decode
+      + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
 
 - name: Create nginx certs Secret
   ansible.builtin.copy:
     content: "{{ secret_content | to_nice_yaml(indent=2) }}"
     dest: "{{ nginx_certs_config }}"
+    mode: "0600"
   vars:
     secret_content:
       kind: Secret
@@ -72,6 +76,7 @@
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
     dest: "{{ nginx_config }}"
+    mode: "0600"
   vars:
     configmap_content:
       kind: ConfigMap

--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -76,6 +76,10 @@
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir
           + '/ingress-fulcio.key') | list | first).content }}
 
+- name: Load nginx config content
+  ansible.builtin.set_fact:
+    nginx_config_content: "{{ lookup('ansible.builtin.template', 'configs/nginx.conf.j2') }}"
+
 - name: Create nginx config ConfigMap
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
@@ -89,8 +93,7 @@
         name: nginx-config
         namespace: nginx-system
       data:
-        nginx.conf: |
-          {{ lookup('ansible.builtin.template', 'configs/nginx.conf.j2') }}
+        nginx.conf: "{{ nginx_config_content }}"
 
 - name: Deploy nginx Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml

--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -30,24 +30,24 @@
 
 - name: Base64 encode the rekor ingress
   ansible.builtin.set_fact:
-    rekor_ingress_base64: >
-      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-rekor.pem') | list | first).content
+    rekor_ingress_base64: >-
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-rekor.pem') | list | first).content
       | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
-      | b64decode }}"
+      | b64decode }}
 
 - name: Base64 encode the tuf ingress
   ansible.builtin.set_fact:
-    tuf_ingress_base64: >
-      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tuf.pem') | list | first).content
+    tuf_ingress_base64: >-
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tuf.pem') | list | first).content
       | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
-      | b64decode }}"
+      | b64decode }}
 
 - name: Base 64 encode the fulcio ingress
   ansible.builtin.set_fact:
-    fulcio_ingress_base64: >
-      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-fulcio.pem') | list | first).content
+    fulcio_ingress_base64: >-
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-fulcio.pem') | list | first).content
       | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
-      | b64decode }}"
+      | b64decode }}
 
 - name: Create nginx certs Secret
   ansible.builtin.copy:
@@ -72,7 +72,7 @@
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-rekor.key') | list | first).content }}
         ingress-tuf.key: |
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tuf.key') | list | first).content }}
-        ingress-fulcio.key: >
+        ingress-fulcio.key: >-
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir
           + '/ingress-fulcio.key') | list | first).content }}
 

--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -2,54 +2,57 @@
 - name: Confirmed required parameters provided
   ansible.builtin.assert:
     that:
-      - base_hostname is defined
-      - base_hostname | trim | length > 0
-    msg: "'base_hostname' must be specified"
+      - tas_single_node_base_hostname is defined
+      - tas_single_node_base_hostname | trim | length > 0
+    msg: "'tas_single_node_base_hostname' must be specified"
 
-- name: Get sigstore network details
+- name: Get RHTAS network details
   containers.podman.podman_network:
-    name: "{{ sigstore_podman_network }}"
-  register: sigstore_podman_network_results
+    name: "{{ tas_single_node_podman_network }}"
+  register: tas_podman_network_results
 
 - name: Set DNS Resolver
   ansible.builtin.set_fact:
-    dns_resolver: "{{ sigstore_podman_network_results.network.subnets[0].gateway }}"
+    dns_resolver: "{{ tas_podman_network_results.network.subnets[0].gateway }}"
 
 - name: Slurp ingress Certificates
   ansible.builtin.slurp:
     src: "{{ item }}"
   loop:
-    - "{{ remote_sigstore_ca }}"
-    - "{{ certs_dir }}/ingress-rekor.pem"
-    - "{{ certs_dir }}/ingress-rekor.key"
-    - "{{ certs_dir }}/ingress-tuf.pem"
-    - "{{ certs_dir }}/ingress-tuf.key"
-    - "{{ certs_dir }}/ingress-fulcio.pem"
-    - "{{ certs_dir }}/ingress-fulcio.key"
+    - "{{ tas_single_node_remote_ca }}"
+    - "{{ tas_single_node_certs_dir }}/ingress-rekor.pem"
+    - "{{ tas_single_node_certs_dir }}/ingress-rekor.key"
+    - "{{ tas_single_node_certs_dir }}/ingress-tuf.pem"
+    - "{{ tas_single_node_certs_dir }}/ingress-tuf.key"
+    - "{{ tas_single_node_certs_dir }}/ingress-fulcio.pem"
+    - "{{ tas_single_node_certs_dir }}/ingress-fulcio.key"
   register: remote_ingress_certificates
 
 - name: Base64 encode the rekor ingress
   ansible.builtin.set_fact:
     rekor_ingress_base64: >
-      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-rekor.pem') | list | first).content | b64decode
-      + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
+      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-rekor.pem') | list | first).content
+      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode }}"
 
 - name: Base64 encode the tuf ingress
   ansible.builtin.set_fact:
     tuf_ingress_base64: >
-      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-tuf.pem') | list | first).content | b64decode
-      + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
+      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tuf.pem') | list | first).content
+      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode }}"
 
 - name: Base 64 encode the fulcio ingress
   ansible.builtin.set_fact:
     fulcio_ingress_base64: >
-      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-fulcio.pem') | list | first).content | b64decode
-      + (remote_ingress_certificates.results | selectattr('source', 'equalto', remote_sigstore_ca) | list | first).content | b64decode }}"
+      "{{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-fulcio.pem') | list | first).content
+      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode }}"
 
 - name: Create nginx certs Secret
   ansible.builtin.copy:
     content: "{{ secret_content | to_nice_yaml(indent=2) }}"
-    dest: "{{ nginx_certs_config }}"
+    dest: "{{ tas_single_node_nginx_certs_config }}"
     mode: "0600"
   vars:
     secret_content:
@@ -66,16 +69,16 @@
         ingress-fulcio.pem: |
           {{ fulcio_ingress_base64 | b64encode }}
         ingress-rekor.key: |
-          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-rekor.key') | list | first).content }}
+          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-rekor.key') | list | first).content }}
         ingress-tuf.key: |
-          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-tuf.key') | list | first).content }}
+          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tuf.key') | list | first).content }}
         ingress-fulcio.key: |
-          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', certs_dir + '/ingress-fulcio.key') | list | first).content }}
+          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-fulcio.key') | list | first).content }}
 
 - name: Create nginx config ConfigMap
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
-    dest: "{{ nginx_config }}"
+    dest: "{{ tas_single_node_nginx_config }}"
     mode: "0600"
   vars:
     configmap_content:
@@ -93,8 +96,8 @@
   vars:
     podman_spec:
       state: started
-      network: "{{ sigstore_podman_network }}"
+      network: "{{ tas_single_node_podman_network }}"
       systemd_file: nginx
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/nginx/nginx.yaml') | from_yaml }}"
-      configmap: "{{ nginx_config }}"
-      secret: "{{ nginx_certs_config }}"
+      configmap: "{{ tas_single_node_nginx_config }}"
+      secret: "{{ tas_single_node_nginx_certs_config }}"

--- a/roles/tas_single_node/tasks/podman/rekor.yml
+++ b/roles/tas_single_node/tasks/podman/rekor.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Obtain Trillian Tree ID
   ansible.builtin.include_tasks: podman/createtree.yml
 
@@ -21,8 +20,8 @@
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:
     podman_spec:
-      state: "started"
-      systemd_file: "redis"
+      state: started
+      systemd_file: redis
       network: "{{ sigstore_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/redis-server.yaml') | from_yaml }}"
 
@@ -30,8 +29,8 @@
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:
     podman_spec:
-      state: "started"
-      systemd_file: "rekor"
+      state: started
+      systemd_file: rekor
       network: "{{ sigstore_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/rekor-server.yaml') | from_yaml }}"
       configmap: "{{ rekor_sharding_config }}"

--- a/roles/tas_single_node/tasks/podman/rekor.yml
+++ b/roles/tas_single_node/tasks/podman/rekor.yml
@@ -5,7 +5,7 @@
 - name: Create Rekor Sharding ConfigMap
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
-    dest: "{{ rekor_sharding_config }}"
+    dest: "{{ tas_single_node_rekor_sharding_config }}"
     mode: "0600"
   vars:
     configmap_content:
@@ -23,7 +23,7 @@
     podman_spec:
       state: started
       systemd_file: redis
-      network: "{{ sigstore_podman_network }}"
+      network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/redis-server.yaml') | from_yaml }}"
 
 - name: Deploy Rekor Server Pod
@@ -32,6 +32,6 @@
     podman_spec:
       state: started
       systemd_file: rekor
-      network: "{{ sigstore_podman_network }}"
+      network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/rekor-server.yaml') | from_yaml }}"
-      configmap: "{{ rekor_sharding_config }}"
+      configmap: "{{ tas_single_node_rekor_sharding_config }}"

--- a/roles/tas_single_node/tasks/podman/rekor.yml
+++ b/roles/tas_single_node/tasks/podman/rekor.yml
@@ -6,6 +6,7 @@
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
     dest: "{{ rekor_sharding_config }}"
+    mode: "0600"
   vars:
     configmap_content:
       kind: ConfigMap

--- a/roles/tas_single_node/tasks/podman/trillian.yml
+++ b/roles/tas_single_node/tasks/podman/trillian.yml
@@ -7,10 +7,10 @@
     data: "{{ trillian_mysql_secret | to_json }}"
   vars:
     trillian_mysql_secret:
-      mysql-root-password: "{{ trillian.mysql.rootPassword | b64encode }}"
-      mysql-password: "{{ trillian.mysql.password | b64encode }}"
-      mysql-database: "{{ trillian.mysql.database | b64encode }}"
-      mysql-user: "{{ trillian.mysql.user | b64encode }}"
+      mysql-root-password: "{{ tas_single_node_trillian.mysql.rootPassword | b64encode }}"
+      mysql-password: "{{ tas_single_node_trillian.mysql.password | b64encode }}"
+      mysql-database: "{{ tas_single_node_trillian.mysql.database | b64encode }}"
+      mysql-user: "{{ tas_single_node_trillian.mysql.user | b64encode }}"
 
 - name: Build Trillian Database Manifest specs
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -18,9 +18,9 @@
     podman_spec:
       state: started
       systemd_file: trillian-mysql
-      network: "{{ sigstore_podman_network }}"
+      network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/trillian/trillian-mysql.yaml') | from_yaml }}"
-  when: trillian.database_deploy
+  when: tas_single_node_trillian.database_deploy
 
 - name: Build Trillian Log Signer Manifest specs
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -28,7 +28,7 @@
     podman_spec:
       state: started
       systemd_file: trillian-signer
-      network: "{{ sigstore_podman_network }}"
+      network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/trillian/trillian-logsigner.yaml') | from_yaml }}"
 
 - name: Build Trillian Log Server Manifest specs
@@ -37,5 +37,5 @@
     podman_spec:
       state: started
       systemd_file: trillian-server
-      network: "{{ sigstore_podman_network }}"
+      network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/trillian/trillian-logserver.yaml') | from_yaml }}"

--- a/roles/tas_single_node/tasks/podman/trillian.yml
+++ b/roles/tas_single_node/tasks/podman/trillian.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create Trillian Secret
   containers.podman.podman_secret:
     name: trillian-mysql
@@ -8,17 +7,17 @@
     data: "{{ trillian_mysql_secret | to_json }}"
   vars:
     trillian_mysql_secret:
-      "mysql-root-password": "{{ trillian.mysql.rootPassword | b64encode }}"
-      "mysql-password": "{{ trillian.mysql.password | b64encode }}"
-      "mysql-database": "{{ trillian.mysql.database | b64encode }}"
-      "mysql-user": "{{ trillian.mysql.user | b64encode }}"
+      mysql-root-password: "{{ trillian.mysql.rootPassword | b64encode }}"
+      mysql-password: "{{ trillian.mysql.password | b64encode }}"
+      mysql-database: "{{ trillian.mysql.database | b64encode }}"
+      mysql-user: "{{ trillian.mysql.user | b64encode }}"
 
 - name: Build Trillian Database Manifest specs
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:
     podman_spec:
-      state: "started"
-      systemd_file: "trillian-mysql"
+      state: started
+      systemd_file: trillian-mysql
       network: "{{ sigstore_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/trillian/trillian-mysql.yaml') | from_yaml }}"
   when: trillian.database_deploy
@@ -27,8 +26,8 @@
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:
     podman_spec:
-      state: "started"
-      systemd_file: "trillian-signer"
+      state: started
+      systemd_file: trillian-signer
       network: "{{ sigstore_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/trillian/trillian-logsigner.yaml') | from_yaml }}"
 
@@ -36,7 +35,7 @@
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:
     podman_spec:
-      state: "started"
-      systemd_file: "trillian-server"
+      state: started
+      systemd_file: trillian-server
       network: "{{ sigstore_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/trillian/trillian-logserver.yaml') | from_yaml }}"

--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -2,28 +2,28 @@
 - name: Confirmed required parameters provided
   ansible.builtin.assert:
     that:
-      - base_hostname is defined
-      - base_hostname | trim | length > 0
-    msg: "'base_hostname' must be specified"
+      - tas_single_node_base_hostname is defined
+      - tas_single_node_base_hostname | trim | length > 0
+    msg: "'tas_single_node_base_hostname' must be specified"
 
 - name: Slurp tuf Certificates
   ansible.builtin.slurp:
     src: "{{ item }}"
   loop:
-    - "{{ remote_ctlog_public_key }}"
-    - "{{ remote_fulcio_root_ca }}"
+    - "{{ tas_single_node_remote_ctlog_public_key }}"
+    - "{{ tas_single_node_remote_fulcio_root_ca }}"
   register: remote_tuf_certificates
 
 - name: Retrieve Rekor Public Key
   ansible.builtin.uri:
-    url: https://rekor.{{ base_hostname }}/api/v1/log/publicKey
+    url: https://rekor.{{ tas_single_node_base_hostname }}/api/v1/log/publicKey
     method: GET
     status_code: 200
     validate_certs: false
     return_content: true
   until: rekor_public_key_result.status == 200
-  retries: "{{ rekor_public_key_retries }}"
-  delay: "{{ rekor_public_key_delay }}"
+  retries: "{{ tas_single_node_rekor_public_key_retries }}"
+  delay: "{{ tas_single_node_rekor_public_key_delay }}"
   register: rekor_public_key_result
   delegate_to: localhost
   become: false
@@ -31,7 +31,7 @@
 - name: Create tuf Secret
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
-    dest: "{{ tuf_secret_config }}"
+    dest: "{{ tas_single_node_tuf_secret_config }}"
     mode: "0600"
   vars:
     configmap_content:
@@ -42,9 +42,9 @@
         namespace: tuf-system
       data:
         ctlog-pubkey: |
-          {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', remote_ctlog_public_key) | list | first).content }}
+          {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ctlog_public_key) | list | first).content }}
         fulcio-cert: |
-          {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', remote_fulcio_root_ca) | list | first).content }}
+          {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}
         rekor-pubkey: |
           {{ rekor_public_key_result.content | b64encode }}
 
@@ -54,6 +54,6 @@
     podman_spec:
       state: started
       systemd_file: tuf
-      network: "{{ sigstore_podman_network }}"
+      network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/tuf/tuf.yaml') | from_yaml }}"
-      secret: "{{ tuf_secret_config }}"
+      secret: "{{ tas_single_node_tuf_secret_config }}"

--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -32,6 +32,7 @@
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
     dest: "{{ tuf_secret_config }}"
+    mode: "0600"
   vars:
     configmap_content:
       kind: Secret

--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Confirmed required parameters provided
   ansible.builtin.assert:
     that:
@@ -17,12 +16,12 @@
 
 - name: Retrieve Rekor Public Key
   ansible.builtin.uri:
-    url: "https://rekor.{{ base_hostname }}/api/v1/log/publicKey"
+    url: https://rekor.{{ base_hostname }}/api/v1/log/publicKey
     method: GET
     status_code: 200
     validate_certs: false
     return_content: true
-  until: "rekor_public_key_result.status == 200"
+  until: rekor_public_key_result.status == 200
   retries: "{{ rekor_public_key_retries }}"
   delay: "{{ rekor_public_key_delay }}"
   register: rekor_public_key_result
@@ -52,8 +51,8 @@
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:
     podman_spec:
-      state: "started"
-      systemd_file: "tuf"
+      state: started
+      systemd_file: tuf
       network: "{{ sigstore_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/tuf/tuf.yaml') | from_yaml }}"
       secret: "{{ tuf_secret_config }}"

--- a/roles/tas_single_node/templates/configs/ctlog-config.j2
+++ b/roles/tas_single_node/templates/configs/ctlog-config.j2
@@ -1,2 +1,2 @@
 backends:{backend:{name:"trillian"  backend_spec:"trillian-logserver-pod:8091"}}  
-log_configs:{config:{log_id:{{ trillian_tree_id }}  prefix:"{{ ct_logprefix }}"  roots_pem_file:"/ctfe-keys/fulcio-0"  private_key:{[type.googleapis.com/keyspb.PEMKeyFile]:{path:"/ctfe-keys/private"  password:"{{ ctlog_ca_passphrase }}"}}  ext_key_usages:"CodeSigning"  log_backend_name:"trillian"}}
+log_configs:{config:{log_id:{{ trillian_tree_id }}  prefix:"{{ tas_single_node_ct_logprefix }}"  roots_pem_file:"/ctfe-keys/fulcio-0"  private_key:{[type.googleapis.com/keyspb.PEMKeyFile]:{path:"/ctfe-keys/private"  password:"{{ tas_single_node_ctlog_ca_passphrase }}"}}  ext_key_usages:"CodeSigning"  log_backend_name:"trillian"}}

--- a/roles/tas_single_node/templates/configs/etc-hosts.j2
+++ b/roles/tas_single_node/templates/configs/etc-hosts.j2
@@ -1,3 +1,3 @@
 {% for item in ['fulcio','tuf', 'rekor'] %}
-{{ hostvars[inventory_hostname].ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }} {{ item }}.{{ base_hostname }}
+{{ hostvars[inventory_hostname].ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }} {{ item }}.{{ tas_single_node_base_hostname }}
 {% endfor %}

--- a/roles/tas_single_node/templates/configs/fulcio-oidc.conf.j2
+++ b/roles/tas_single_node/templates/configs/fulcio-oidc.conf.j2
@@ -1,9 +1,9 @@
 {
     "OIDCIssuers": {
-    "{{ oidc_issuers }}": {
-        "ClientID": "{{ sigstore_client_id }}",
-        "IssuerURL": "{{ issuer_url }}",
-        "Type": "{{  oidc_issuers_type }}"
+    "{{ tas_single_node_oidc_issuers }}": {
+        "ClientID": "{{ tas_single_node_oidc_client_id }}",
+        "IssuerURL": "{{ tas_single_node_issuer_url }}",
+        "Type": "{{ tas_single_node_oidc_issuers_type }}"
         }
     }
 }

--- a/roles/tas_single_node/templates/configs/nginx.conf.j2
+++ b/roles/tas_single_node/templates/configs/nginx.conf.j2
@@ -45,38 +45,38 @@ stream {
 
   map_hash_bucket_size 128;
   map $ssl_server_name $targetBackend {
-{% if rekor_enabled %}
-    rekor.{{ base_hostname }}  rekor-server-pod:3000;
+{% if tas_single_node_rekor_enabled %}
+    rekor.{{ tas_single_node_base_hostname }}  rekor-server-pod:3000;
 {% endif %}
-{% if tuf_enabled %}
-    tuf.{{ base_hostname }}  tuf-pod:8080;
+{% if tas_single_node_tuf_enabled %}
+    tuf.{{ tas_single_node_base_hostname }}  tuf-pod:8080;
 {% endif %}
-{% if fulcio_enabled %}
-    fulcio.{{ base_hostname }}  fulcio-server-pod:5555;
+{% if tas_single_node_fulcio_enabled %}
+    fulcio.{{ tas_single_node_base_hostname }}  fulcio-server-pod:5555;
 {% endif %}
   }
 
   map $ssl_server_name $targetCert {
-{% if rekor_enabled %}
-    rekor.{{ base_hostname }} /certs/ingress-rekor.pem;
+{% if tas_single_node_rekor_enabled %}
+    rekor.{{ tas_single_node_base_hostname }} /certs/ingress-rekor.pem;
 {% endif %}
-{% if tuf_enabled %}
-    tuf.{{ base_hostname }} /certs/ingress-tuf.pem;
+{% if tas_single_node_tuf_enabled %}
+    tuf.{{ tas_single_node_base_hostname }} /certs/ingress-tuf.pem;
 {% endif %}
-{% if fulcio_enabled %}
-    fulcio.{{ base_hostname }} /certs/ingress-fulcio.pem;
+{% if tas_single_node_fulcio_enabled %}
+    fulcio.{{ tas_single_node_base_hostname }} /certs/ingress-fulcio.pem;
 {% endif %}
   }
 
   map $ssl_server_name $targetCertKey {
-{% if rekor_enabled %}
-    rekor.{{ base_hostname }}  /certs/ingress-rekor.key;
+{% if tas_single_node_rekor_enabled %}
+    rekor.{{ tas_single_node_base_hostname }}  /certs/ingress-rekor.key;
 {% endif %}
-{% if tuf_enabled %}
-    tuf.{{ base_hostname }}  /certs/ingress-tuf.key;
+{% if tas_single_node_tuf_enabled %}
+    tuf.{{ tas_single_node_base_hostname }}  /certs/ingress-tuf.key;
 {% endif %}
-{% if fulcio_enabled %}
-    fulcio.{{ base_hostname }}  /certs/ingress-fulcio.key;
+{% if tas_single_node_fulcio_enabled %}
+    fulcio.{{ tas_single_node_base_hostname }}  /certs/ingress-fulcio.key;
 {% endif %}
   }
   

--- a/roles/tas_single_node/templates/manifests/ctlog/ctlog.yaml
+++ b/roles/tas_single_node/templates/manifests/ctlog/ctlog.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: ctlog
-          image: {{ ct_server_image }}
+          image: {{ tas_single_node_ct_server_image }}
           imagePullPolicy: IfNotPresent
           livelinessProbe:
             failureThreshold: 3

--- a/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.yaml
+++ b/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.yaml
@@ -33,12 +33,12 @@ spec:
             - --fileca-cert
             - /var/run/fulcio-secrets/cert.pem
             - --fileca-key-passwd
-            - {{ fulcio_ca_passphrase  }}
-            - --ct-log-url=http://ctlog-pod:6962/{{ ct_logprefix }}
+            - {{ tas_single_node_fulcio_ca_passphrase  }}
+            - --ct-log-url=http://ctlog-pod:6962/{{ tas_single_node_ct_logprefix }}
           env:
             - name: SSL_CERT_DIR
               value: /certs
-          image: {{ fulcio_server_image }}
+          image: {{ tas_single_node_fulcio_server_image }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5555

--- a/roles/tas_single_node/templates/manifests/nginx/nginx.yaml
+++ b/roles/tas_single_node/templates/manifests/nginx/nginx.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: nginx
           # 1.20
-          image: {{ nginx_image }}
+          image: {{ tas_single_node_nginx_image }}
           args:
             - nginx
             - -g

--- a/roles/tas_single_node/templates/manifests/rekor/redis-server.yaml
+++ b/roles/tas_single_node/templates/manifests/rekor/redis-server.yaml
@@ -32,7 +32,7 @@ spec:
             - 0.0.0.0
             - --appendonly
             - "yes"
-          image: {{ redis_image }}
+          image: {{ tas_single_node_redis_image }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6379

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.yaml
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.yaml
@@ -48,7 +48,7 @@ spec:
             - --trillian_log_server.tlog_id={{ trillian_tree_id }}
             - --enable_attestation_storage
             - --attestation_storage_bucket=file:///var/run/attestations
-          image: {{ rekor_image }}
+          image: {{ tas_single_node_rekor_image }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.yaml
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.yaml
@@ -23,12 +23,12 @@ spec:
     spec:
       containers:
         - name: trillian-trillian-logserver
-          image: {{ trillian_log_server_image }}
+          image: {{ tas_single_node_trillian_log_server_image }}
           imagePullPolicy: IfNotPresent
           args:
             - --storage_system=mysql
             - --quota_system=mysql
-            - --mysql_uri={{ trillian.mysql.user }}:{{ trillian.mysql.password }}@tcp({{ trillian.mysql.host }}:{{ trillian.mysql.port }})/{{ trillian.mysql.database }}
+            - --mysql_uri={{ tas_single_node_trillian.mysql.user }}:{{ tas_single_node_trillian.mysql.password }}@tcp({{ tas_single_node_trillian.mysql.host }}:{{ tas_single_node_trillian.mysql.port }})/{{ tas_single_node_trillian.mysql.database }}
             - --rpc_endpoint=0.0.0.0:8091
             - --http_endpoint=0.0.0.0:8090
             - --alsologtostderr
@@ -49,9 +49,9 @@ spec:
                   key: mysql-database
                   name: trillian-mysql
             - name: MYSQL_HOSTNAME
-              value: {{ trillian.mysql.host }}
+              value: {{ tas_single_node_trillian.mysql.host }}
             - name: MYSQL_PORT
-              value: "{{ trillian.mysql.port | quote }})"
+              value: "{{ tas_single_node_trillian.mysql.port | quote }})"
           ports:
             - containerPort: 8091
               protocol: TCP
@@ -62,7 +62,7 @@ spec:
           terminationMessagePolicy: File
       initContainers:
         - name: wait-for-trillian-db
-          image: {{ netcat_image }}
+          image: {{ tas_single_node_netcat_image }}
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c", "until nc -z -w 10 trillian-mysql-pod 3306; do echo waiting for trillian-mysql; sleep 5; done;"]
           resources: {}

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.yaml
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-trillian-db
-          image: {{ netcat_image}}
+          image: {{ tas_single_node_netcat_image}}
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c", "until nc -z -w 10 trillian-mysql-pod 3306; do echo waiting for trillian-mysql-pod; sleep 5; done;"]
           resources: {}
@@ -34,7 +34,7 @@ spec:
           terminationMessagePolicy: File
       containers:
         - name: trillian-trillian-logsigner
-          image: {{ trillian_logsigner_image }}
+          image: {{ tas_single_node_trillian_logsigner_image }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8191
@@ -42,7 +42,7 @@ spec:
           args:
             - --storage_system=mysql
             - --quota_system=mysql
-            - --mysql_uri={{ trillian.mysql.user }}:{{ trillian.mysql.password }}@tcp({{ trillian.mysql.host }}:{{ trillian.mysql.port }})/{{ trillian.mysql.database }}
+            - --mysql_uri={{ tas_single_node_trillian.mysql.user }}:{{ tas_single_node_trillian.mysql.password }}@tcp({{ tas_single_node_trillian.mysql.host }}:{{ tas_single_node_trillian.mysql.port }})/{{ tas_single_node_trillian.mysql.database }}
             - --rpc_endpoint=0.0.0.0:8091
             - --http_endpoint=0.0.0.0:8090
             - --force_master=true
@@ -64,9 +64,9 @@ spec:
                   key: mysql-database
                   name: trillian-mysql
             - name: MYSQL_HOSTNAME
-              value: {{ trillian.mysql.host }}
+              value: {{ tas_single_node_trillian.mysql.host }}
             - name: MYSQL_PORT
-              value: "{{ trillian.mysql.port | quote }})"
+              value: "{{ tas_single_node_trillian.mysql.port | quote }})"
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-mysql.yaml
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-mysql.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: trillian-mysql
-          image: {{ trillian_db_image }}
+          image: {{ tas_single_node_trillian_db_image }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3306

--- a/roles/tas_single_node/templates/manifests/tuf/tuf.yaml
+++ b/roles/tas_single_node/templates/manifests/tuf/tuf.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: tuf
-          image: {{ tuf_image }}
+          image: {{ tas_single_node_tuf_image }}
           # image: ghcr.io/sigstore/scaffolding/server@sha256:719ea3fe44c52af5a5fedab2168429872e37e97b9f063977fc164d60a5a14b53
           imagePullPolicy: IfNotPresent
           ports:

--- a/roles/tas_single_node/tests/test.yml
+++ b/roles/tas_single_node/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Install TAS locally
+  hosts: localhost
   remote_user: root
   roles:
-    - sigstore_scaffolding
+    - tas_single_node

--- a/vm-testing/requirements.yml
+++ b/vm-testing/requirements.yml
@@ -1,5 +1,4 @@
 ---
 
 collections:
-  - fedora.linux_system_roles
   - community.crypto


### PR DESCRIPTION
This PR:
* Makes our code pass ansible-lint
* Introduces a new GH Action to run ansible-lint on the code
* Adds the Apache-2.0 license (license is required to pass ansible-lint)
* Replaces occurences of "sigstore" with "tas" where it makes sense (I did this while renaming the variables, because I was touching all the variable names anyway because of ansible-lint)