### PR TITLE
Fix idempotency of podman tasks and conditions for pod restarts

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,8 @@ authors:
 description: TODO
 license_file: Apache-2.0
 tags: [sigstore, tas, rhtas, security, cosign]
-dependencies: {}
+dependencies:
+  containers.podman: ">=1.15.0"
 repository: https://github.com/securesign/artifact-signer-ansible/
 documentation: http://TODO.com
 homepage: https://TODO.com

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -84,6 +84,7 @@ tas_single_node_treeid_config: "{{ tas_single_node_kube_configmap_dir }}/treeid-
 tas_single_node_rekor_sharding_config: "{{ tas_single_node_kube_configmap_dir }}/rekor-sharding-config.yaml"
 tas_single_node_nginx_config: "{{ tas_single_node_kube_configmap_dir }}/nginx-config.yaml"
 tas_single_node_nginx_certs_config: "{{ tas_single_node_kube_configmap_dir }}/nginx-certs.yaml"
+tas_single_node_trillian_secret: "{{ tas_single_node_kube_configmap_dir }}/trillian-secret.yaml"
 tas_single_node_systemd_directory: /etc/systemd/system
 
 tas_single_node_setup_host_dns: true

--- a/roles/tas_single_node/tasks/podman/ctlog.yml
+++ b/roles/tas_single_node/tasks/podman/ctlog.yml
@@ -49,6 +49,7 @@
           {{ (remote_ctlog_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ctlog_public_key) | list | first).content }}
         fulcio-0: |
           {{ (remote_ctlog_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}
+  register: secret_result
 
 - name: Deploy ctlog Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -60,3 +61,4 @@
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/ctlog/ctlog.yaml') | from_yaml }}"
       configmap: "{{ tas_single_node_ctlog_configmap_config }}"
       secret: "{{ tas_single_node_ctlog_secret }}"
+      secret_changed: "{{ secret_result.changed }}"

--- a/roles/tas_single_node/tasks/podman/fulcio.yml
+++ b/roles/tas_single_node/tasks/podman/fulcio.yml
@@ -55,6 +55,7 @@
         public: |
           {{ (remote_fulcio_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_public_key) | list | first).content }}
         password: "{{ tas_single_node_fulcio_ca_passphrase | b64encode }}"
+  register: secret_result
 
 - name: Deploy Fulcio Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -66,3 +67,4 @@
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/fulcio/fulcio-server.yaml') | from_yaml }}"
       configmap: "{{ tas_single_node_fulcio_server_config }}"
       secret: "{{ tas_single_node_fulcio_server_secret_config }}"
+      secret_changed: "{{ secret_result.changed }}"

--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -1,4 +1,7 @@
 ---
+# NOTE: determining when the service will restart with `when: ...` is not ideal, however
+# we would need a dynamic handler otherwise and these are a bit fragile.
+
 - name: Set location of Podman Play Manifest
   ansible.builtin.set_fact:
     kube_play_file: >-
@@ -10,12 +13,19 @@
     content: "{{ podman_spec.kube_file_content | to_nice_yaml(indent=2) }}"
     dest: "{{ kube_play_file }}"
     mode: "0600"
+  register: copy_manifest
 
 - name: Create Secret
+  # We can't use podman_secret because we support Podman 4.4.1 and the podman_secret module only
+  # supports idempotency with >= 4.7.0: https://github.com/containers/ansible-podman-collections/issues/692
+  # Unfortunately podman_play doesn't properly understand idempotency with secrets either
+  # The next best thing is to identify whether the secret file changed - this is determined from the secret_changed
+  # variable passed by the caller to this file
   containers.podman.podman_play:
     kube_file: "{{ podman_spec.secret }}"
     state: "{{ podman_spec.state | default('started') }}"
   when: podman_spec.secret is defined
+  changed_when: podman_spec.secret is defined and podman_spec.secret_changed
 
 - name: Copy Systemd file to Server
   ansible.builtin.template:
@@ -23,6 +33,7 @@
     dest: "{{ tas_single_node_systemd_directory + '/' + podman_spec.systemd_file }}.service"
     mode: "0600"
   when: podman_spec.configmap is defined
+  register: copy_systemd_file
 
 - name: Copy Systemd file to Server
   ansible.builtin.template:
@@ -30,10 +41,12 @@
     dest: "{{ tas_single_node_systemd_directory + '/' + podman_spec.systemd_file }}.service"
     mode: "0600"
   when: podman_spec.configmap is not defined
+  register: copy_systemd_file
 
-- name: Start Podman Service
+- name: Restart Podman Service
   ansible.builtin.systemd:
-    state: started
+    state: restarted
     enabled: true
     daemon_reload: true
     name: "{{ podman_spec.systemd_file }}"
+  when: copy_manifest.changed or copy_systemd_file.changed or (podman_spec.secret is defined and podman_spec.secret_changed)

--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -75,6 +75,7 @@
         ingress-fulcio.key: >-
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir
           + '/ingress-fulcio.key') | list | first).content }}
+  register: secret_result
 
 - name: Load nginx config content
   ansible.builtin.set_fact:
@@ -105,3 +106,4 @@
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/nginx/nginx.yaml') | from_yaml }}"
       configmap: "{{ tas_single_node_nginx_config }}"
       secret: "{{ tas_single_node_nginx_certs_config }}"
+      secret_changed: "{{ secret_result.changed }}"

--- a/roles/tas_single_node/tasks/podman/trillian.yml
+++ b/roles/tas_single_node/tasks/podman/trillian.yml
@@ -1,16 +1,22 @@
 ---
 - name: Create Trillian Secret
-  containers.podman.podman_secret:
-    name: trillian-mysql
-    state: present
-    force: true
-    data: "{{ trillian_mysql_secret | to_json }}"
+  ansible.builtin.copy:
+    content: "{{ secret_content | to_nice_yaml(indent=2) }}"
+    dest: "{{ tas_single_node_trillian_secret }}"
+    mode: "0600"
   vars:
-    trillian_mysql_secret:
-      mysql-root-password: "{{ tas_single_node_trillian.mysql.rootPassword | b64encode }}"
-      mysql-password: "{{ tas_single_node_trillian.mysql.password | b64encode }}"
-      mysql-database: "{{ tas_single_node_trillian.mysql.database | b64encode }}"
-      mysql-user: "{{ tas_single_node_trillian.mysql.user | b64encode }}"
+    secret_content:
+      kind: Secret
+      apiVersion: v1
+      metadata:
+        name: trillian-mysql
+        namespace: trillian-system
+      data:
+        mysql-root-password: "{{ tas_single_node_trillian.mysql.rootPassword | b64encode }}"
+        mysql-password: "{{ tas_single_node_trillian.mysql.password | b64encode }}"
+        mysql-database: "{{ tas_single_node_trillian.mysql.database | b64encode }}"
+        mysql-user: "{{ tas_single_node_trillian.mysql.user | b64encode }}"
+  register: secret_result
 
 - name: Build Trillian Database Manifest specs
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -20,6 +26,8 @@
       systemd_file: trillian-mysql
       network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/trillian/trillian-mysql.yaml') | from_yaml }}"
+      secret: "{{ tas_single_node_trillian_secret }}"
+      secret_changed: "{{ secret_result.changed }}"
   when: tas_single_node_trillian.database_deploy
 
 - name: Build Trillian Log Signer Manifest specs
@@ -30,6 +38,8 @@
       systemd_file: trillian-signer
       network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/trillian/trillian-logsigner.yaml') | from_yaml }}"
+      secret: "{{ tas_single_node_trillian_secret }}"
+      secret_changed: "{{ secret_result.changed }}"
 
 - name: Build Trillian Log Server Manifest specs
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -39,3 +49,5 @@
       systemd_file: trillian-server
       network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/trillian/trillian-logserver.yaml') | from_yaml }}"
+      secret: "{{ tas_single_node_trillian_secret }}"
+      secret_changed: "{{ secret_result.changed }}"

--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -47,6 +47,7 @@
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}
         rekor-pubkey: |
           {{ rekor_public_key_result.content | b64encode }}
+  register: secret_result
 
 - name: Deploy tuf Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -57,3 +58,4 @@
       network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/tuf/tuf.yaml') | from_yaml }}"
       secret: "{{ tas_single_node_tuf_secret_config }}"
+      secret_changed: "{{ secret_result.changed }}"


### PR DESCRIPTION
This change addresses some issues around the podman logic:

* Ensures we restart podman pods under the right conditions (when config, secret or service file change)
* Implements proper idempotency for the related tasks
* Makes us depend on podman collection >= 1.15.0 which seems to have bunch of idempotency fixes