### PR TITLE
Upgrade image versions to 1.0.2 release, except the TUF image

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -105,21 +105,22 @@ tas_single_node_oidc_issuers_type: email
 
 # RHTAS Images
 tas_single_node_fulcio_server_image:
-  quay.io/redhat-user-workloads/rhtas-tenant/fulcio/fulcio-server@sha256:f333772eb0cd23360516da4a7a50813a59d67c690c2b6baef4bc4b6094d1116b
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:e16accb01b2ca6bf4ebd60c6ce7faab73b784828578ee74305a3a97ff9db1e26"
 tas_single_node_trillian_log_server_image:
-  quay.io/redhat-user-workloads/rhtas-tenant/trillian/logserver@sha256:cdb2fa8ef85a9727c2b306652e4127ee4b2723cd361a04f364f4a96d60194777
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:1673f08529a94671f881edec6fd29b73f43c2115dc86b643f9dd79d7e36be38e"
 tas_single_node_trillian_logsigner_image:
-  quay.io/redhat-user-workloads/rhtas-tenant/trillian/logsigner@sha256:f8199e0b14f391574181a3e38659a2ec5baeb65ba5101ac63b5b9785ae01c214
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:758bfd5455d0ca96f5404229a73fdcd56686564fc4c315ca3468ebe8588dd9ca"
 tas_single_node_rekor_image:
-  quay.io/redhat-user-workloads/rhtas-tenant/rekor/rekor-server@sha256:a2075576589bec3c4544db4368732cb1388e8f5a3cb2a739d943cee601e64b74
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:d4ea970447f3b4c18c309d2f0090a5d02260dd5257a0d41f87fefc4f014a9526"
 tas_single_node_ct_server_image:
-  quay.io/redhat-user-workloads/rhtas-tenant/certificate-transparency-go/certificate-transparency-go@sha256:1419a048cb5095b3f65d08224e6f94c6eb166d8d5a16707942aed2880992ddee
-
-# Supplement images
-tas_single_node_redis_image: quay.io/redhat-user-workloads/rhtas-tenant/trillian/redis@sha256:0804a6634b8836cb2e957ee16d54e8d6ab94d311362a48baf238b1f575d79934
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:0765d248fd1c4b4f8cbcbee23f35506c08c9eeb96a8b0e8ff1511319be6c0ae6"
+tas_single_node_redis_image:
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:06382df99dfff9f002365a31eee0855f8032e351bc9583e42e489ab7623fe287"
 tas_single_node_trillian_db_image:
-  quay.io/redhat-user-workloads/rhtas-tenant/trillian/database@sha256:145560da2f030ab6574d62c912b757d5537e75e4ec10e0d26cf56a67b1573969
-tas_single_node_tuf_image: quay.io/securesign/tuf/server:latest
-tas_single_node_netcat_image: registry.redhat.io/openshift4/ose-tools-rhel8@sha256:486b4d2dd0d10c5ef0212714c94334e04fe8a3d36cf619881986201a50f123c7
-tas_single_node_nginx_image: registry.redhat.io/rhel8/nginx-122@sha256:088912945049dbb83bc2e8a70732059e4baca7462447c738f4a9ab34ecc705da
-tas_single_node_curl_image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:58140d6b7fee762b148336b342a6745b1910ab758a701b2e8077b1fca2af1180"
+tas_single_node_tuf_image:
+  "quay.io/securesign/tuf/server:latest"
+tas_single_node_netcat_image:
+  "registry.redhat.io/openshift4/ose-tools-rhel8@sha256:486b4d2dd0d10c5ef0212714c94334e04fe8a3d36cf619881986201a50f123c7"
+tas_single_node_nginx_image:
+  "registry.redhat.io/rhel9/nginx-124@sha256:71fc4492c3a632663c1e17ec9364d87aa7bd459d3c723277b8b94a949b84c9fe"

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -32,7 +32,6 @@
       "{{ tas_single_node_tuf_enabled }}",
       "{{ tas_single_node_trillian_enabled }}",
       "true",
-      "true"
     ]
   loop:
     - "{{ tas_single_node_fulcio_server_image }}"
@@ -45,7 +44,6 @@
     - "{{ tas_single_node_tuf_image }}"
     - "{{ tas_single_node_netcat_image }}"
     - "{{ tas_single_node_nginx_image }}"
-    - "{{ tas_single_node_curl_image }}"
   loop_control:
     index_var: idx
   when: enabled_vals[idx] | bool

--- a/roles/tas_single_node/templates/manifests/tuf/tuf.yaml
+++ b/roles/tas_single_node/templates/manifests/tuf/tuf.yaml
@@ -27,7 +27,6 @@ spec:
       containers:
         - name: tuf
           image: {{ tas_single_node_tuf_image }}
-          # image: ghcr.io/sigstore/scaffolding/server@sha256:719ea3fe44c52af5a5fedab2168429872e37e97b9f063977fc164d60a5a14b53
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8082


### PR DESCRIPTION
TUF image upgrade is currently blocked on https://github.com/sigstore/scaffolding/pull/1159. I will open another PR to get it upgraded as soon as we have a new working TUF image.