### PR TITLE
Avoid requiring resolution of base_hostname for applying tas_single_node

### DIFF
--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -16,7 +16,7 @@
 
 - name: Retrieve Rekor Public Key
   ansible.builtin.uri:
-    url: https://rekor.{{ tas_single_node_base_hostname }}/api/v1/log/publicKey
+    url: http://localhost:3000/api/v1/log/publicKey
     method: GET
     status_code: 200
     validate_certs: false
@@ -25,8 +25,6 @@
   retries: "{{ tas_single_node_rekor_public_key_retries }}"
   delay: "{{ tas_single_node_rekor_public_key_delay }}"
   register: rekor_public_key_result
-  delegate_to: localhost
-  become: false
 
 - name: Create tuf Secret
   ansible.builtin.copy:


### PR DESCRIPTION
We can fetch the rekor pubkey locally on the managed node. This is the only part that required the ability to resolve base_hostname when applying the role. With this fix, base_hostname no longer needs to resolve on the control node to apply the tas_single_node role.

Note: because we do this locally on the managed node and the pubkey doesn't go over any network, we can also use http instead of https.