### PR TITLE
[SECURESIGN-1174] Add Timestamp Authority

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -52,6 +52,10 @@ tas_single_node_ctlog_private_key_filename: ctlog.key
 tas_single_node_ctlog_public_key_filename: ctlog.pub
 tas_single_node_rekor_signer_filename: rekor-signer.key
 tas_single_node_rekor_public_key_filename: rekor-pub-key.pub
+tas_single_node_tsa_private_key_filename: tsa.key
+tas_single_node_tsa_certificate_chain_filename: certificate-chain.pem
+tas_single_node_tsa_intermediate_certificate_filename: intermediate-certificate.pem
+tas_single_node_tsa_signer_private_key_filename: signer-private-key.pem
 
 tas_single_node_local_private_key: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_private_key_filename }}"
 tas_single_node_local_ca: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_ca_filename }}"
@@ -94,7 +98,26 @@ tas_single_node_fulcio_enabled: true
 tas_single_node_fulcio_ca_passphrase: rhtas
 tas_single_node_ctlog_ca_passphrase: rhtas
 tas_single_node_rekor_ca_passphrase: rhtas
+tas_single_node_tsa_ca_passphrase: rhtas
+tas_single_node_tsa_signer_passphrase: rhtas
 tas_single_node_ct_logprefix: rhtasansible
+
+tas_single_node_tsa_enabled: true
+tas_single_node_signer_type: file
+tas_single_node_local_tsa_certificate_chain: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_tsa_certificate_chain_filename }}"
+tas_single_node_local_tsa_intermediate_certificate: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_tsa_intermediate_certificate_filename }}"
+tas_single_node_local_tsa_signer_private_key: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_tsa_signer_private_key_filename }}"
+tas_single_node_remote_tsa_signer_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_signer_private_key_filename }}"
+tas_single_node_remote_tsa_certificate_chain: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_certificate_chain_filename }}"
+tas_single_node_local_tsa_private_key: "{{ tas_single_node_local_certs_dir }}/{{ tas_single_node_tsa_private_key_filename }}"
+tas_single_node_remote_tsa_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_private_key_filename }}"
+
+tas_single_node_tsa_secret: "{{ tas_single_node_kube_configmap_dir }}/tsa-secret.yaml"
+
+tas_single_node_kms_key_resource: ""
+tas_single_node_tink_key_resource: ""
+tas_single_node_tsa_tink_keyset: ""
+tas_single_node_tink_hcvault_token: ""
 
 tas_single_node_scaffolding_utils_image: quay.io/ablock/sigstore-scaffolding-helper:latest
 
@@ -124,3 +147,5 @@ tas_single_node_netcat_image:
   "registry.redhat.io/openshift4/ose-tools-rhel8@sha256:486b4d2dd0d10c5ef0212714c94334e04fe8a3d36cf619881986201a50f123c7"
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:71fc4492c3a632663c1e17ec9364d87aa7bd459d3c723277b8b94a949b84c9fe"
+tas_single_node_tsa_image:
+  "quay.io/redhat-user-workloads/rhtas-tenant/timestamp-authority/timestamp-authority@sha256:a13834438c2b7f9441535783880daa01e1cdb1f26255311352b38ebbb154abac"

--- a/roles/tas_single_node/tasks/certificates.yml
+++ b/roles/tas_single_node/tasks/certificates.yml
@@ -64,6 +64,7 @@
     - fulcio
     - rekor
     - tuf
+    - tsa
   loop_control:
     loop_var: cert_name
   vars:
@@ -135,6 +136,101 @@
         path: "{{ tas_single_node_local_ctlog_public_key }}"
         privatekey_path: "{{ tas_single_node_local_ctlog_private_key }}"
         privatekey_passphrase: "{{ tas_single_node_ctlog_ca_passphrase }}"
+
+- name: Handle TSA certificate chain
+  delegate_to: localhost
+  block:
+    - name: Create TSA root Private Key
+      community.crypto.openssl_privatekey:
+        path: "{{ tas_single_node_local_tsa_private_key }}"
+        curve: secp256r1
+        type: ECC
+        passphrase: "{{ tas_single_node_tsa_ca_passphrase }}"
+        cipher: auto
+      when: >
+        (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_private_key) | list | length) == 0
+        and (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
+        and tas_single_node_signer_type == 'file'
+
+    - name: Create certificate signing request (CSR) for TSA Root certificate
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: "{{ tas_single_node_local_tsa_private_key }}"
+        privatekey_passphrase: "{{ tas_single_node_tsa_ca_passphrase }}"
+        common_name: "Root CA"
+        basic_constraints:
+          - CA:TRUE
+        basic_constraints_critical: true
+        key_usage:
+          - keyCertSign
+      register: tsa_root_csr
+      when: >
+        (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
+        and tas_single_node_signer_type == 'file'
+
+    - name: Create self-signed TSA root CA from CSR
+      community.crypto.x509_certificate:
+        path: "{{ tas_single_node_local_tsa_certificate_chain }}"
+        csr_content: "{{ tsa_root_csr.csr }}"
+        privatekey_path: "{{ tas_single_node_local_tsa_private_key }}"
+        privatekey_passphrase: "{{ tas_single_node_tsa_ca_passphrase }}"
+        provider: selfsigned
+      when: >
+        (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
+        and tas_single_node_signer_type == 'file'
+
+    # Intermediate certificate
+    - name: Create TSA intermediate CA Private Key
+      community.crypto.openssl_privatekey:
+        path: "{{ tas_single_node_local_tsa_signer_private_key }}"
+        curve: secp256r1
+        type: ECC
+        passphrase: "{{ tas_single_node_tsa_ca_passphrase }}"
+        cipher: auto
+      when: >
+        (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
+        and (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_signer_private_key) | list | length) == 0
+        and tas_single_node_signer_type == 'file'
+
+    - name: Create TSA intermediate CA CSR
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: "{{ tas_single_node_local_tsa_signer_private_key }}"
+        privatekey_passphrase: "{{ tas_single_node_tsa_signer_passphrase }}"
+        common_name: "Intermediate CA"
+        basic_constraints:
+          - CA:TRUE
+        basic_constraints_critical: true
+        key_usage:
+          - keyCertSign
+        extended_key_usage:
+          - "1.3.6.1.5.5.7.3.8"
+        extended_key_usage_critical: true
+      register: tsa_intermediate_csr
+      when: >
+        (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
+        and tas_single_node_signer_type == 'file'
+
+    - name: Sign Intermediate CA with Root CA
+      community.crypto.x509_certificate:
+        path: "{{ tas_single_node_local_tsa_intermediate_certificate }}"
+        csr_content: "{{ tsa_intermediate_csr.csr }}"
+        ownca_path: "{{ tas_single_node_local_tsa_certificate_chain }}"
+        ownca_privatekey_path: "{{ tas_single_node_local_tsa_private_key }}"
+        ownca_privatekey_passphrase: "{{ tas_single_node_tsa_ca_passphrase }}"
+        provider: ownca
+      when: >
+        (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
+        and tas_single_node_signer_type == 'file'
+
+    - name: Combine Intermediate and Root CA certificates into a chain
+      ansible.builtin.command: >
+        /bin/bash -c '
+        cat {{ tas_single_node_local_tsa_intermediate_certificate }} {{ tas_single_node_local_tsa_certificate_chain }} > /tmp/certificate-chain.tmp &&
+        mv /tmp/certificate-chain.tmp {{ tas_single_node_local_tsa_certificate_chain }};'
+      register: result
+      changed_when: "'changed' in result.stdout"
+      when: >
+        (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
+        and tas_single_node_signer_type == 'file'
 
 - name: Copy Certificates to Server
   become: true

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -31,6 +31,7 @@
       "{{ tas_single_node_trillian_enabled }}",
       "{{ tas_single_node_tuf_enabled }}",
       "{{ tas_single_node_trillian_enabled }}",
+      "{{ tas_single_node_tsa_enabled }}",
       "true",
     ]
   loop:
@@ -44,33 +45,38 @@
     - "{{ tas_single_node_tuf_image }}"
     - "{{ tas_single_node_netcat_image }}"
     - "{{ tas_single_node_nginx_image }}"
+    - "{{ tas_single_node_tsa_image }}"
   loop_control:
     index_var: idx
   when: enabled_vals[idx] | bool
 
-- name: Configure/Deploy nginx
-  ansible.builtin.include_tasks: podman/nginx.yml
+# - name: Configure/Deploy nginx
+#   ansible.builtin.include_tasks: podman/nginx.yml
 
-- name: Configure/Deploy Trillian
-  ansible.builtin.include_tasks: podman/trillian.yml
-  when: tas_single_node_trillian_enabled | bool
+# - name: Configure/Deploy Trillian
+#   ansible.builtin.include_tasks: podman/trillian.yml
+#   when: tas_single_node_trillian_enabled | bool
 
-- name: Setup Trillian Tree ID
-  ansible.builtin.include_tasks: podman/createtree.yml
-  when: tas_single_node_trillian_enabled | bool
+# - name: Setup Trillian Tree ID
+#   ansible.builtin.include_tasks: podman/createtree.yml
+#   when: tas_single_node_trillian_enabled | bool
 
-- name: Configure/Deploy Rekor
-  ansible.builtin.include_tasks: podman/rekor.yml
-  when: tas_single_node_rekor_enabled | bool
+# - name: Configure/Deploy Rekor
+#   ansible.builtin.include_tasks: podman/rekor.yml
+#   when: tas_single_node_rekor_enabled | bool
 
-- name: Configure/Deploy Fulcio
-  ansible.builtin.include_tasks: podman/fulcio.yml
-  when: tas_single_node_fulcio_enabled | bool
+# - name: Configure/Deploy Fulcio
+#   ansible.builtin.include_tasks: podman/fulcio.yml
+#   when: tas_single_node_fulcio_enabled | bool
 
-- name: Configure/Deploy ctlog
-  ansible.builtin.include_tasks: podman/ctlog.yml
-  when: tas_single_node_ctlog_enabled | bool
+# - name: Configure/Deploy ctlog
+#   ansible.builtin.include_tasks: podman/ctlog.yml
+#   when: tas_single_node_ctlog_enabled | bool
 
-- name: Configure/Deploy tuf
-  ansible.builtin.include_tasks: podman/tuf.yml
-  when: tas_single_node_tuf_enabled | bool
+# - name: Configure/Deploy tuf
+#   ansible.builtin.include_tasks: podman/tuf.yml
+#   when: tas_single_node_tuf_enabled | bool
+
+- name: Configure/Deploy TSA
+  ansible.builtin.include_tasks: podman/tsa.yml
+  when: tas_single_node_tsa_enabled | bool

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -50,32 +50,32 @@
     index_var: idx
   when: enabled_vals[idx] | bool
 
-# - name: Configure/Deploy nginx
-#   ansible.builtin.include_tasks: podman/nginx.yml
+- name: Configure/Deploy nginx
+  ansible.builtin.include_tasks: podman/nginx.yml
 
-# - name: Configure/Deploy Trillian
-#   ansible.builtin.include_tasks: podman/trillian.yml
-#   when: tas_single_node_trillian_enabled | bool
+- name: Configure/Deploy Trillian
+  ansible.builtin.include_tasks: podman/trillian.yml
+  when: tas_single_node_trillian_enabled | bool
 
-# - name: Setup Trillian Tree ID
-#   ansible.builtin.include_tasks: podman/createtree.yml
-#   when: tas_single_node_trillian_enabled | bool
+- name: Setup Trillian Tree ID
+  ansible.builtin.include_tasks: podman/createtree.yml
+  when: tas_single_node_trillian_enabled | bool
 
-# - name: Configure/Deploy Rekor
-#   ansible.builtin.include_tasks: podman/rekor.yml
-#   when: tas_single_node_rekor_enabled | bool
+- name: Configure/Deploy Rekor
+  ansible.builtin.include_tasks: podman/rekor.yml
+  when: tas_single_node_rekor_enabled | bool
 
-# - name: Configure/Deploy Fulcio
-#   ansible.builtin.include_tasks: podman/fulcio.yml
-#   when: tas_single_node_fulcio_enabled | bool
+- name: Configure/Deploy Fulcio
+  ansible.builtin.include_tasks: podman/fulcio.yml
+  when: tas_single_node_fulcio_enabled | bool
 
-# - name: Configure/Deploy ctlog
-#   ansible.builtin.include_tasks: podman/ctlog.yml
-#   when: tas_single_node_ctlog_enabled | bool
+- name: Configure/Deploy ctlog
+  ansible.builtin.include_tasks: podman/ctlog.yml
+  when: tas_single_node_ctlog_enabled | bool
 
-# - name: Configure/Deploy tuf
-#   ansible.builtin.include_tasks: podman/tuf.yml
-#   when: tas_single_node_tuf_enabled | bool
+- name: Configure/Deploy tuf
+  ansible.builtin.include_tasks: podman/tuf.yml
+  when: tas_single_node_tuf_enabled | bool
 
 - name: Configure/Deploy TSA
   ansible.builtin.include_tasks: podman/tsa.yml

--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -26,6 +26,8 @@
     - "{{ tas_single_node_certs_dir }}/ingress-tuf.key"
     - "{{ tas_single_node_certs_dir }}/ingress-fulcio.pem"
     - "{{ tas_single_node_certs_dir }}/ingress-fulcio.key"
+    - "{{ tas_single_node_certs_dir }}/ingress-tsa.pem"
+    - "{{ tas_single_node_certs_dir }}/ingress-tsa.key"
   register: remote_ingress_certificates
 
 - name: Base64 encode the rekor ingress
@@ -49,6 +51,13 @@
       | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
       | b64decode }}
 
+- name: Base 64 encode the tsa ingress
+  ansible.builtin.set_fact:
+    tsa_ingress_base64: >-
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tsa.pem') | list | first).content
+      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode }}
+
 - name: Create nginx certs Secret
   ansible.builtin.copy:
     content: "{{ secret_content | to_nice_yaml(indent=2) }}"
@@ -68,6 +77,8 @@
           {{ tuf_ingress_base64 | b64encode }}
         ingress-fulcio.pem: |
           {{ fulcio_ingress_base64 | b64encode }}
+        ingress-tsa.pem: |
+          {{ tsa_ingress_base64 | b64encode }}
         ingress-rekor.key: |
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-rekor.key') | list | first).content }}
         ingress-tuf.key: |
@@ -75,6 +86,8 @@
         ingress-fulcio.key: >-
           {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir
           + '/ingress-fulcio.key') | list | first).content }}
+        ingress-tsa.key: |
+          {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tsa.key') | list | first).content }}
   register: secret_result
 
 - name: Load nginx config content

--- a/roles/tas_single_node/tasks/podman/tsa.yml
+++ b/roles/tas_single_node/tasks/podman/tsa.yml
@@ -1,0 +1,56 @@
+---
+- name: Confirmed required parameters provided
+  ansible.builtin.assert:
+    that:
+      - tas_single_node_base_hostname is defined
+      - tas_single_node_base_hostname | trim | length > 0
+    msg: "'tas_single_node_base_hostname' must be specified"
+
+- name: Slurp TSA Certificates chain
+  ansible.builtin.slurp:
+    src: "{{ item }}"
+  loop:
+    - "{{ tas_single_node_remote_tsa_private_key }}"
+    - "{{ tas_single_node_remote_tsa_certificate_chain }}"
+    - "{{ tas_single_node_remote_tsa_signer_private_key }}"
+  register: remote_tsa_certificates
+
+- name: Define TSA base secret data
+  ansible.builtin.set_fact:
+    secret_data:
+      private_key.pem: |
+        {{ (remote_tsa_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_tsa_signer_private_key) | list | first).content }}
+      certificate-chain.pem: |
+        {{ (remote_tsa_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | first).content }}
+      password: "{{ tas_single_node_tsa_signer_passphrase | b64encode }}"
+
+- name: Append Tink secret data
+  ansible.builtin.set_fact:
+    secret_data: "{{ secret_data | combine({'encrypted_key_set': tas_single_node_tsa_tink_keyset | b64encode}) }}"
+  when: tas_single_node_signer_type == 'tink'
+
+- name: Create TSA Secret
+  ansible.builtin.copy:
+    content: "{{ secret_content | to_nice_yaml(indent=2) }}"
+    dest: "{{ tas_single_node_tsa_secret }}"
+    mode: "0600"
+  vars:
+    secret_content:
+      kind: Secret
+      apiVersion: v1
+      metadata:
+        name: tsa-server-secret
+        namespace: tsa-system
+      data: "{{ secret_data }}"
+  register: tsa_secret_result
+
+- name: Deploy TSA Pod
+  ansible.builtin.include_tasks: podman/install_manifest.yml
+  vars:
+    podman_spec:
+      state: started
+      systemd_file: tsa
+      network: "{{ tas_single_node_podman_network }}"
+      kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/tsa/tsa-server.j2') | from_yaml }}"
+      secret: "{{ tas_single_node_tsa_secret }}"
+      secret_changed: "{{ tsa_secret_result.changed }}"

--- a/roles/tas_single_node/templates/configs/nginx.conf.j2
+++ b/roles/tas_single_node/templates/configs/nginx.conf.j2
@@ -54,6 +54,9 @@ stream {
 {% if tas_single_node_fulcio_enabled %}
     fulcio.{{ tas_single_node_base_hostname }}  fulcio-server-pod:5555;
 {% endif %}
+{% if tas_single_node_tsa_enabled %}
+    tsa.{{ tas_single_node_base_hostname }}  tsa-server-pod:3002;
+{% endif %}
   }
 
   map $ssl_server_name $targetCert {
@@ -66,6 +69,9 @@ stream {
 {% if tas_single_node_fulcio_enabled %}
     fulcio.{{ tas_single_node_base_hostname }} /certs/ingress-fulcio.pem;
 {% endif %}
+{% if tas_single_node_tsa_enabled %}
+    tsa.{{ tas_single_node_base_hostname }} /certs/ingress-tsa.pem;
+{% endif %}
   }
 
   map $ssl_server_name $targetCertKey {
@@ -77,6 +83,9 @@ stream {
 {% endif %}
 {% if tas_single_node_fulcio_enabled %}
     fulcio.{{ tas_single_node_base_hostname }}  /certs/ingress-fulcio.key;
+{% endif %}
+{% if tas_single_node_tsa_enabled %}
+    tsa.{{ tas_single_node_base_hostname }}  /certs/ingress-tsa.key;
 {% endif %}
   }
   

--- a/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
+++ b/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tsa-server
+  namespace: tsa-system
+  labels:
+    app.kubernetes.io/instance: scaffold
+    app.kubernetes.io/name: tsa
+    pod-template-hash: 74d5ff6f7f
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tsa-server
+  template:
+    metadata:
+      labels:
+        app: tsa-server
+        app.kubernetes.io/instance: scaffold
+        app.kubernetes.io/name: tsa
+        pod-template-hash: 74d5ff6f7f
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - name: tsa-server
+          image: {{ tas_single_node_tsa_image }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - "timestamp-server"
+          args:
+            - "serve"
+            - "--host=0.0.0.0"
+            - "--port=3002"
+            - "--certificate-chain-path=/etc/secrets/cert_chain/certificate-chain.pem"
+            - "--timestamp-signer={{ tas_single_node_signer_type }}"
+{% if tas_single_node_signer_type == 'file' %}
+            - "--file-signer-key-path=/etc/secrets/keys/private_key.pem"
+            - "--file-signer-passwd={{ tas_single_node_tsa_signer_passphrase }}"
+{% endif %}
+{% if tas_single_node_signer_type == 'kms' %}
+            - '--kms-key-resource={{ tas_single_node_kms_key_resource }}"
+{% endif %}
+{% if tas_single_node_signer_type == 'tink' %}
+            - '--tink-key-resource={{ tas_single_node_tink_key_resource }}"
+            - '--tink-keyset-path=/etc/secrets/keys/encrypted_key_set"
+            - '--tink-hcvault-token={{ tas_single_node_tink_hcvault_token }}"
+{% endif %}
+          ports:
+            - containerPort: 3002
+              hostPort: 3002
+              protocol: TCP
+          resources: {}
+          volumeMounts:
+            - name: tsa-cert-chain
+              mountPath: /etc/secrets/cert_chain
+              readOnly: true
+{% if tas_single_node_signer_type == 'file' %}
+            - name: tsa-file-signer-config
+              mountPath: /etc/secrets/keys
+              readOnly: true
+{% endif %}
+{% if tas_single_node_signer_type == 'tink' %}
+            - name: tsa-file-signer-config
+              mountPath: /etc/secrets/keys
+              readOnly: true
+{% endif %}
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65533
+      serviceAccountName: tsa-server
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 300
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 300
+      volumes:
+        - name: tsa-cert-chain
+          secret:
+            secretName: tsa-server-secret
+            items:
+              - key: certificate-chain.pem
+                path: certificate-chain.pem
+{% if tas_single_node_signer_type == 'file' %}
+        - name: tsa-file-signer-config
+          secret:
+            secretName: tsa-server-secret
+            items:
+              - key: private_key.pem
+                path: private_key.pem
+{% endif %}
+{% if tas_single_node_signer_type == 'tink' %}
+        - name: tsa-file-signer-config
+          secret:
+            secretName: tsa-server-secret
+            items:
+              - key: encrypted_key_set
+                path: encrypted_key_set
+{% endif %}

--- a/vm-testing/test.sh
+++ b/vm-testing/test.sh
@@ -31,6 +31,7 @@ podman run \
   --add-host fulcio."${base_hostname}":"${ip_address}" \
   --add-host rekor."${base_hostname}":"${ip_address}" \
   --add-host tuf."${base_hostname}":"${ip_address}" \
+  --add-host tsa."${base_hostname}":"${ip_address}" \
   -e BASE_HOSTNAME="${base_hostname}" \
   -e USERNAME="${username}" \
   -e PASSWORD="${password}" \

--- a/vm-testing/test/test-sign-blob.sh
+++ b/vm-testing/test/test-sign-blob.sh
@@ -18,6 +18,7 @@ export TUF_URL=https://tuf.$BASE_HOSTNAME
 export OIDC_ISSUER_URL=$KEYCLOAK_URL/auth/realms/$KEYCLOAK_REALM
 export COSIGN_FULCIO_URL=https://fulcio.$BASE_HOSTNAME
 export COSIGN_REKOR_URL=https://rekor.$BASE_HOSTNAME
+export COSIGN_TSA_URL=https://tsa.$BASE_HOSTNAME/api/v1/timestamp
 export COSIGN_MIRROR=$TUF_URL
 export COSIGN_ROOT=$TUF_URL/root.json
 export COSIGN_OIDC_CLIENT_ID=$KEYCLOAK_REALM
@@ -37,5 +38,7 @@ cosign initialize
 
 echo "testing" > to-sign
 
-cosign --verbose sign-blob to-sign --bundle signed.bundle --identity-token="${TOKEN}"
-cosign verify-blob --certificate-identity="${USERNAME}"@redhat.com --bundle signed.bundle to-sign
+cosign --verbose sign-blob to-sign --bundle signed.bundle --identity-token="${TOKEN}" --timestamp-server-url=${COSIGN_TSA_URL} --rfc3161-timestamp=timestamp.txt
+
+curl ${COSIGN_TSA_URL}/certchain > tsa_chain.pem
+cosign verify-blob --certificate-identity="${USERNAME}"@redhat.com --bundle signed.bundle to-sign --timestamp-certificate-chain=tsa_chain.pem --rfc3161-timestamp=timestamp.txt

--- a/vm-testing/test/test-sign-blob.sh
+++ b/vm-testing/test/test-sign-blob.sh
@@ -38,7 +38,7 @@ cosign initialize
 
 echo "testing" > to-sign
 
-cosign --verbose sign-blob to-sign --bundle signed.bundle --identity-token="${TOKEN}" --timestamp-server-url=${COSIGN_TSA_URL} --rfc3161-timestamp=timestamp.txt
+cosign --verbose sign-blob to-sign --bundle signed.bundle --identity-token="${TOKEN}" --timestamp-server-url="${COSIGN_TSA_URL}" --rfc3161-timestamp=timestamp.txt
 
-curl ${COSIGN_TSA_URL}/certchain > tsa_chain.pem
+curl "${COSIGN_TSA_URL}"/certchain > tsa_chain.pem
 cosign verify-blob --certificate-identity="${USERNAME}"@redhat.com --bundle signed.bundle to-sign --timestamp-certificate-chain=tsa_chain.pem --rfc3161-timestamp=timestamp.txt


### PR DESCRIPTION
Add Timestamp Authority server on port 3002.
Updated vm_testing/test.sh to use it instead of Rekor TSA.

## Testing command:
```
./vm_testing/test.sh
```
Expected Result: `...Verified OK`