### PR TITLE
Fix syntax of ctlog url passed to fulcio server

### DIFF
--- a/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.yaml
+++ b/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.yaml
@@ -34,7 +34,7 @@ spec:
             - /var/run/fulcio-secrets/cert.pem
             - --fileca-key-passwd
             - "{{ tas_single_node_fulcio_ca_passphrase }}"
-            - --ct-log-url="http://ctlog-pod:6962/{{ tas_single_node_ct_logprefix }}"
+            - "--ct-log-url=http://ctlog-pod:6962/{{ tas_single_node_ct_logprefix }}"
           env:
             - name: SSL_CERT_DIR
               value: /certs


### PR DESCRIPTION
The quotes weren't recognized as YAML element, but as part of the string and passed verbatim to the fulcio server, which made it fail to communicate with ctlog server.