### PR TITLE
[SECURESIGN-1116] Add option to use external customer provisioned Redis

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -19,7 +19,14 @@ tas_single_node_skip_os_install: false
 
 tas_single_node_rekor_templates:
   - manifests/rekor/redis-server.yaml
-  - manifests/rekor/rekor-server.yaml
+  - manifests/rekor/rekor-server.j2
+
+tas_single_node_rekor_redis:
+  database_deploy: true
+  redis:
+    address: "rekor-redis"
+    port: 6379
+    password: ""
 
 tas_single_node_cockpit_enabled: true
 tas_single_node_ctlog_enabled: true

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -18,15 +18,15 @@ tas_single_node_cockpit:
 tas_single_node_skip_os_install: false
 
 tas_single_node_rekor_templates:
-  - manifests/rekor/redis-server.yaml
+  - manifests/rekor/redis-server.j2
   - manifests/rekor/rekor-server.j2
 
 tas_single_node_rekor_redis:
   database_deploy: true
   redis:
-    address: "rekor-redis"
+    address: rekor-redis-pod
     port: 6379
-    password: ""
+    password: password
 
 tas_single_node_cockpit_enabled: true
 tas_single_node_ctlog_enabled: true

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -17,30 +17,6 @@
   register: podman_login_result
   changed_when: '"Already logged in" not in podman_login_result'
 
-- name: Define images base list
-  ansible.builtin.set_fact:
-    images_list: [
-      "{{ tas_single_node_fulcio_server_image }}",
-      "{{ tas_single_node_trillian_log_server_image }}",
-      "{{ tas_single_node_trillian_logsigner_image }}",
-      "{{ tas_single_node_rekor_image }}",
-      "{{ tas_single_node_ct_server_image }}",
-      "{{ tas_single_node_tuf_image }}",
-      "{{ tas_single_node_netcat_image }}",
-      "{{ tas_single_node_nginx_image }}",
-      "{{ tas_single_node_tsa_image }}",
-    ]
-
-- name: Add Redis image to the list
-  ansible.builtin.set_fact:
-    images_list: "{{ images_list + ['{{ tas_single_node_redis_image }}'] }}"
-  when: tas_single_node_rekor_redis.database_deploy
-
-- name: Add Trillian DB image to the list
-  ansible.builtin.set_fact:
-    images_list: "{{ images_list + ['{{ tas_single_node_trillian_db_image }}'] }}"
-  when: tas_single_node_trillian.database_deploy
-
 - name: Pull all images
   containers.podman.podman_image:
     name: "{{ item }}"
@@ -51,14 +27,25 @@
       "{{ tas_single_node_trillian_enabled }}",
       "{{ tas_single_node_rekor_enabled }}",
       "{{ tas_single_node_ctlog_enabled }}",
-      "{{ tas_single_node_rekor_enabled }}",
-      "{{ tas_single_node_trillian_enabled }}",
+      "{{ tas_single_node_rekor_enabled and tas_single_node_rekor_redis.database_deploy }}",
+      "{{ tas_single_node_trillian_enabled and tas_single_node_trillian.database_deploy}}",
       "{{ tas_single_node_tuf_enabled }}",
       "{{ tas_single_node_trillian_enabled }}",
-      "{{ tas_single_node_tsa_enabled }}",
       "true",
+      "{{ tas_single_node_tsa_enabled }}",
     ]
-  loop: "{{ images_list }}"
+  loop:
+    - "{{ tas_single_node_fulcio_server_image }}"
+    - "{{ tas_single_node_trillian_log_server_image }}"
+    - "{{ tas_single_node_trillian_logsigner_image }}"
+    - "{{ tas_single_node_rekor_image }}"
+    - "{{ tas_single_node_ct_server_image }}"
+    - "{{ tas_single_node_redis_image }}"
+    - "{{ tas_single_node_trillian_db_image }}"
+    - "{{ tas_single_node_tuf_image }}"
+    - "{{ tas_single_node_netcat_image }}"
+    - "{{ tas_single_node_nginx_image }}"
+    - "{{ tas_single_node_tsa_image }}"
   loop_control:
     index_var: idx
   when: enabled_vals[idx] | bool

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -78,18 +78,18 @@
   ansible.builtin.include_tasks: podman/rekor.yml
   when: tas_single_node_rekor_enabled | bool
 
-# - name: Configure/Deploy Fulcio
-#   ansible.builtin.include_tasks: podman/fulcio.yml
-#   when: tas_single_node_fulcio_enabled | bool
+- name: Configure/Deploy Fulcio
+  ansible.builtin.include_tasks: podman/fulcio.yml
+  when: tas_single_node_fulcio_enabled | bool
 
-# - name: Configure/Deploy ctlog
-#   ansible.builtin.include_tasks: podman/ctlog.yml
-#   when: tas_single_node_ctlog_enabled | bool
+- name: Configure/Deploy ctlog
+  ansible.builtin.include_tasks: podman/ctlog.yml
+  when: tas_single_node_ctlog_enabled | bool
 
-# - name: Configure/Deploy tuf
-#   ansible.builtin.include_tasks: podman/tuf.yml
-#   when: tas_single_node_tuf_enabled | bool
+- name: Configure/Deploy tuf
+  ansible.builtin.include_tasks: podman/tuf.yml
+  when: tas_single_node_tuf_enabled | bool
 
-# - name: Configure/Deploy TSA
-#   ansible.builtin.include_tasks: podman/tsa.yml
-#   when: tas_single_node_tsa_enabled | bool
+- name: Configure/Deploy TSA
+  ansible.builtin.include_tasks: podman/tsa.yml
+  when: tas_single_node_tsa_enabled | bool

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -28,7 +28,7 @@
       "{{ tas_single_node_rekor_enabled }}",
       "{{ tas_single_node_ctlog_enabled }}",
       "{{ tas_single_node_rekor_enabled and tas_single_node_rekor_redis.database_deploy }}",
-      "{{ tas_single_node_trillian_enabled and tas_single_node_trillian.database_deploy}}",
+      "{{ tas_single_node_trillian_enabled and tas_single_node_trillian.database_deploy }}",
       "{{ tas_single_node_tuf_enabled }}",
       "{{ tas_single_node_trillian_enabled }}",
       "true",

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -17,6 +17,30 @@
   register: podman_login_result
   changed_when: '"Already logged in" not in podman_login_result'
 
+- name: Define images base list
+  ansible.builtin.set_fact:
+    images_list: [
+      "{{ tas_single_node_fulcio_server_image }}",
+      "{{ tas_single_node_trillian_log_server_image }}",
+      "{{ tas_single_node_trillian_logsigner_image }}",
+      "{{ tas_single_node_rekor_image }}",
+      "{{ tas_single_node_ct_server_image }}",
+      "{{ tas_single_node_tuf_image }}",
+      "{{ tas_single_node_netcat_image }}",
+      "{{ tas_single_node_nginx_image }}",
+      "{{ tas_single_node_tsa_image }}",
+    ]
+
+- name: Add Redis image to the list
+  ansible.builtin.set_fact:
+    images_list: "{{ images_list + ['{{ tas_single_node_redis_image }}'] }}"
+  when: tas_single_node_rekor_redis.database_deploy
+
+- name: Add Trillian DB image to the list
+  ansible.builtin.set_fact:
+    images_list: "{{ images_list + ['{{ tas_single_node_trillian_db_image }}'] }}"
+  when: tas_single_node_trillian.database_deploy
+
 - name: Pull all images
   containers.podman.podman_image:
     name: "{{ item }}"
@@ -34,18 +58,7 @@
       "{{ tas_single_node_tsa_enabled }}",
       "true",
     ]
-  loop:
-    - "{{ tas_single_node_fulcio_server_image }}"
-    - "{{ tas_single_node_trillian_log_server_image }}"
-    - "{{ tas_single_node_trillian_logsigner_image }}"
-    - "{{ tas_single_node_rekor_image }}"
-    - "{{ tas_single_node_ct_server_image }}"
-    - "{{ tas_single_node_redis_image }}"
-    - "{{ tas_single_node_trillian_db_image }}"
-    - "{{ tas_single_node_tuf_image }}"
-    - "{{ tas_single_node_netcat_image }}"
-    - "{{ tas_single_node_nginx_image }}"
-    - "{{ tas_single_node_tsa_image }}"
+  loop: "{{ images_list }}"
   loop_control:
     index_var: idx
   when: enabled_vals[idx] | bool
@@ -65,18 +78,18 @@
   ansible.builtin.include_tasks: podman/rekor.yml
   when: tas_single_node_rekor_enabled | bool
 
-- name: Configure/Deploy Fulcio
-  ansible.builtin.include_tasks: podman/fulcio.yml
-  when: tas_single_node_fulcio_enabled | bool
+# - name: Configure/Deploy Fulcio
+#   ansible.builtin.include_tasks: podman/fulcio.yml
+#   when: tas_single_node_fulcio_enabled | bool
 
-- name: Configure/Deploy ctlog
-  ansible.builtin.include_tasks: podman/ctlog.yml
-  when: tas_single_node_ctlog_enabled | bool
+# - name: Configure/Deploy ctlog
+#   ansible.builtin.include_tasks: podman/ctlog.yml
+#   when: tas_single_node_ctlog_enabled | bool
 
-- name: Configure/Deploy tuf
-  ansible.builtin.include_tasks: podman/tuf.yml
-  when: tas_single_node_tuf_enabled | bool
+# - name: Configure/Deploy tuf
+#   ansible.builtin.include_tasks: podman/tuf.yml
+#   when: tas_single_node_tuf_enabled | bool
 
-- name: Configure/Deploy TSA
-  ansible.builtin.include_tasks: podman/tsa.yml
-  when: tas_single_node_tsa_enabled | bool
+# - name: Configure/Deploy TSA
+#   ansible.builtin.include_tasks: podman/tsa.yml
+#   when: tas_single_node_tsa_enabled | bool

--- a/roles/tas_single_node/tasks/podman/rekor.yml
+++ b/roles/tas_single_node/tasks/podman/rekor.yml
@@ -25,6 +25,7 @@
       systemd_file: redis
       network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/redis-server.yaml') | from_yaml }}"
+  when: tas_single_node_rekor_redis.database_deploy
 
 - name: Deploy Rekor Server Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -33,5 +34,5 @@
       state: started
       systemd_file: rekor
       network: "{{ tas_single_node_podman_network }}"
-      kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/rekor-server.yaml') | from_yaml }}"
+      kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/rekor-server.j2') | from_yaml }}"
       configmap: "{{ tas_single_node_rekor_sharding_config }}"

--- a/roles/tas_single_node/tasks/podman/rekor.yml
+++ b/roles/tas_single_node/tasks/podman/rekor.yml
@@ -24,7 +24,7 @@
       state: started
       systemd_file: redis
       network: "{{ tas_single_node_podman_network }}"
-      kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/redis-server.yaml') | from_yaml }}"
+      kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/redis-server.j2') | from_yaml }}"
   when: tas_single_node_rekor_redis.database_deploy
 
 - name: Deploy Rekor Server Pod

--- a/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
@@ -33,6 +33,11 @@ spec:
             - --appendonly
             - "yes"
           image: "{{ tas_single_node_redis_image }}"
+{% if tas_single_node_rekor_redis.redis.password != "" %}
+          env:
+            - name: REDIS_PASSWORD
+              value: "{{ tas_single_node_rekor_redis.redis.password }}"
+{% endif %}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6379

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -43,7 +43,7 @@ spec:
             - --redis_server.address={{ tas_single_node_rekor_redis.redis.address }}
             - --redis_server.port={{ tas_single_node_rekor_redis.redis.port }}
 {% if tas_single_node_rekor_redis.redis.password != "" %}
-            - "--redis_server.password={{ tas_single_node_rekor_redis.redis.password }}
+            - --redis_server.password={{ tas_single_node_rekor_redis.redis.password }}
 {% endif %}
             - --rekor_server.address=0.0.0.0
             - --rekor_server.signer=memory

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -40,8 +40,11 @@ spec:
             - --trillian_log_server.address=trillian-logserver-pod
             - --trillian_log_server.port=8091
             - --trillian_log_server.sharding_config=/sharding/sharding-config.yaml
-            - --redis_server.address=rekor-redis
-            - --redis_server.port=6379
+            - --redis_server.address={{ tas_single_node_rekor_redis.redis.address }}
+            - --redis_server.port={{ tas_single_node_rekor_redis.redis.port }}
+{% if tas_single_node_rekor_redis.redis.password != "" %}
+            - "--redis_server.password={{ tas_single_node_rekor_redis.redis.password }}
+{% endif %}
             - --rekor_server.address=0.0.0.0
             - --rekor_server.signer=memory
             - --enable_retrieve_api=true


### PR DESCRIPTION
### Description
- Add option to use customer provisioned Redis:
To do that:
```
tas_single_node_rekor_redis:
  database_deploy: false
  redis:
    address: "address"
    port: 6379
    password: "password"
```

--- 
- This option is already enabled for Trillian DB. User can disable the creation of the trillian DB using `tas_single_node_trillian.database_deploy ` set to false and provide `mysql` attributes:
```
tas_single_node_trillian:
  mysql:
    database_deploy: false
    user: mysql
    rootPassword: rootpassword
    password: password
    database: trillian
    host: trillian-mysql-pod
    port: 3306
```