### PR TITLE
chore: Fixes and improvements for the vm-testing setup

### DIFF
--- a/vm-testing/inventory-sample
+++ b/vm-testing/inventory-sample
@@ -3,4 +3,5 @@ REMOTE_IP_ADDRESS
 
 [rhtas:vars]
 ansible_user=ANSIBLE_USER
-become=true
+ansible_become=true
+ansible_become_user=root

--- a/vm-testing/provision.sh
+++ b/vm-testing/provision.sh
@@ -17,7 +17,7 @@ else
   exit 1
 fi
 
-(sed -e "s/REMOTE_IP_ADDRESS/$ip_address/" -e "s/ANSIBLE_USER/$vm_username/" inventory-sample > inventory)
+(sed -e "s/REMOTE_IP_ADDRESS/$ip_address/" -e "s/ANSIBLE_USER/$vm_username/" ../inventory-sample > ../inventory)
 
 cat << EOF
 Please add the following lines to your /etc/hosts:

--- a/vm-testing/test/test-sign-blob.sh
+++ b/vm-testing/test/test-sign-blob.sh
@@ -41,4 +41,4 @@ echo "testing" > to-sign
 cosign --verbose sign-blob to-sign --bundle signed.bundle --identity-token="${TOKEN}" --timestamp-server-url="${COSIGN_TSA_URL}" --rfc3161-timestamp=timestamp.txt
 
 curl "${COSIGN_TSA_URL}"/certchain > tsa_chain.pem
-cosign verify-blob --certificate-identity="${USERNAME}"@redhat.com --bundle signed.bundle to-sign --timestamp-certificate-chain=tsa_chain.pem --rfc3161-timestamp=timestamp.txt
+cosign --verbose verify-blob --certificate-identity="${USERNAME}"@redhat.com --bundle signed.bundle to-sign --timestamp-certificate-chain=tsa_chain.pem --rfc3161-timestamp=timestamp.txt


### PR DESCRIPTION
This PR improves/fixes the vm-testing setup:
* Properly overwrite the inventory file regardless where we're calling the provision.sh script from
* Properly set up becoming root in the inventory
* Verify the blob in verbose mode