### PR TITLE
Don't rely on distribution minor version, it's not always present

### DIFF
--- a/roles/tas_single_node/tasks/os_support.yml
+++ b/roles/tas_single_node/tasks/os_support.yml
@@ -9,6 +9,7 @@
   when: (ansible_facts['distribution'] in ['RedHat', 'CentOS'] and
     (ansible_facts['distribution_major_version'] | int < 9 or
     (ansible_facts['distribution_major_version'] | int == 9 and
+    'distribution_minor_version' in ansible_facts and
     ansible_facts['distribution_minor_version'] | int < 2)))
 
 - name: Fail if the architecture is not x86_64


### PR DESCRIPTION
`distribution_minor_version` is not always present, e.g. on CentOS Stream 9. We optimistically assume that when it is missing, we can proceed.