### PR TITLE
[SECURESIGN-1162] Ensuring no tasks changed on Re-Run of Playbook

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -33,8 +33,7 @@ jobs:
             # ensure we wipe out any data potentially still on the runner from previous run
             molecule reset
             # NOTE: for now we don't run "molecule test", because we don't have proper idempotence yet
-            molecule -v converge --scenario-name default
-            molecule -v verify --scenario-name default
+            molecule -v test --scenario-name default
         - name: Destroy molecule infrastructure
           env:
             TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -22,6 +22,7 @@
   ansible.builtin.command: podman login registry.redhat.io -u '{{ tas_single_node_registry_username }}' --password {{ tas_single_node_registry_password }}
   register: podman_login_result
   when: logincheck.stdout | string != tas_single_node_registry_username | string
+  changed_when: true
 
 - name: Pull all images
   containers.podman.podman_image:

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -15,8 +15,8 @@
 - name: Podman check login
   ansible.builtin.command: podman login --get-login registry.redhat.io
   register: loginCheck
-  changed_when: False
-  ignore_errors: true
+  failed_when: loginCheck.stdout == "Nil val"
+  changed_when: loginCheck.stdout | string != tas_single_node_registry_username | string
 
 - name: Podman login to registry.redhat.io
   ansible.builtin.command: podman login registry.redhat.io -u '{{ tas_single_node_registry_username }}' --password {{ tas_single_node_registry_password }}

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -12,17 +12,16 @@
     - "{{ tas_single_node_kube_manifest_dir }}"
     - "{{ tas_single_node_kube_configmap_dir }}"
 
-- name: Podman check login
+- name: Check if Podman is already logged in to registry.redhat.io
   ansible.builtin.command: podman login --get-login registry.redhat.io
   register: logincheck
-  failed_when: logincheck.stdout == "Nil val"
+  failed_when: logincheck.stdout == 'Error":" not logged into registry.redhat.io'
   changed_when: logincheck.stdout | string != tas_single_node_registry_username | string
 
 - name: Podman login to registry.redhat.io
   ansible.builtin.command: podman login registry.redhat.io -u '{{ tas_single_node_registry_username }}' --password {{ tas_single_node_registry_password }}
   register: podman_login_result
   when: logincheck.stdout | string != tas_single_node_registry_username | string
-  changed_when: '"Login Succeeded!" in podman_login_result.stdout'
 
 - name: Pull all images
   containers.podman.podman_image:

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -22,6 +22,7 @@
   ansible.builtin.command: podman login registry.redhat.io -u '{{ tas_single_node_registry_username }}' --password {{ tas_single_node_registry_password }}
   register: podman_login_result
   when: logincheck.stdout | string != tas_single_node_registry_username | string
+  changed_when: '"Login Succeeded!" in podman_login_result.stdout'
 
 - name: Pull all images
   containers.podman.podman_image:

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -14,14 +14,14 @@
 
 - name: Podman check login
   ansible.builtin.command: podman login --get-login registry.redhat.io
-  register: loginCheck
-  failed_when: loginCheck.stdout == "Nil val"
-  changed_when: loginCheck.stdout | string != tas_single_node_registry_username | string
+  register: logincheck
+  failed_when: logincheck.stdout == "Nil val"
+  changed_when: logincheck.stdout | string != tas_single_node_registry_username | string
 
 - name: Podman login to registry.redhat.io
   ansible.builtin.command: podman login registry.redhat.io -u '{{ tas_single_node_registry_username }}' --password {{ tas_single_node_registry_password }}
   register: podman_login_result
-  when: loginCheck.stdout | string != tas_single_node_registry_username | string
+  when: logincheck.stdout | string != tas_single_node_registry_username | string
 
 - name: Pull all images
   containers.podman.podman_image:

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -12,10 +12,16 @@
     - "{{ tas_single_node_kube_manifest_dir }}"
     - "{{ tas_single_node_kube_configmap_dir }}"
 
+- name: Podman check login
+  ansible.builtin.command: podman login --get-login registry.redhat.io
+  register: loginCheck
+  changed_when: False
+  ignore_errors: true
+
 - name: Podman login to registry.redhat.io
   ansible.builtin.command: podman login registry.redhat.io -u '{{ tas_single_node_registry_username }}' --password {{ tas_single_node_registry_password }}
   register: podman_login_result
-  changed_when: '"Already logged in" not in podman_login_result'
+  when: loginCheck.stdout | string != tas_single_node_registry_username | string
 
 - name: Pull all images
   containers.podman.podman_image:


### PR DESCRIPTION
From rerunning the Playbook without making any changes to any of the config the only task that will re-run is the podman login. This task is skipped over if the podman login remains the same.