### PR TITLE
Update TUF server to properly handle running outside of k8s

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -139,7 +139,7 @@ tas_single_node_redis_image:
 tas_single_node_trillian_db_image:
   "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:58140d6b7fee762b148336b342a6745b1910ab758a701b2e8077b1fca2af1180"
 tas_single_node_tuf_image:
-  "quay.io/securesign/tuf/server:latest"
+  "quay.io/securesign/scaffold-tuf-server@sha256:34f5cdc53a908ae2819d85ab18e35b69dc4efc135d747dd1d2e216a99a2dcd1b"
 tas_single_node_netcat_image:
   "registry.redhat.io/openshift4/ose-tools-rhel8@sha256:486b4d2dd0d10c5ef0212714c94334e04fe8a3d36cf619881986201a50f123c7"
 tas_single_node_nginx_image:

--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -39,7 +39,7 @@
         name: tuf-secret
         namespace: tuf-system
       data:
-        ctlog-pubkey: |
+        ctfe-pubkey: |
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ctlog_public_key) | list | first).content }}
         fulcio-cert: |
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}

--- a/roles/tas_single_node/templates/manifests/tuf/tuf.yaml
+++ b/roles/tas_single_node/templates/manifests/tuf/tuf.yaml
@@ -35,6 +35,7 @@ spec:
           env:
             - name: NAMESPACE
               value: tuf-system
+          args: ["-no-k8s"]
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File


### PR DESCRIPTION
This upgrades the TUF server to a build containing https://github.com/sigstore/scaffolding/commit/84f08b9b314b6617ea9de0a4f07be4f427e0c504, making it properly runnable outside of k8s.