### PR TITLE
Ensure that all required system dependencies are of 'latest' version

### DIFF
--- a/roles/tas_single_node/tasks/os.yml
+++ b/roles/tas_single_node/tasks/os.yml
@@ -1,6 +1,10 @@
 ---
 - name: Install System Packages dependencies
-  ansible.builtin.package:
+  # We use noqa here, because having all the packages upgrade to the latest version when
+  # available is actually what we want. We need to prevent locking ourselves at old
+  # version with potential CVEs (at the same time we must upgrade to at least RHEL 9.2
+  # package releases to ensure we can actually work).
+  ansible.builtin.package: # noqa: package-latest
     name: "{{ tas_single_node_system_packages }}"
     state: latest
 

--- a/roles/tas_single_node/tasks/os.yml
+++ b/roles/tas_single_node/tasks/os.yml
@@ -2,6 +2,7 @@
 - name: Install System Packages dependencies
   ansible.builtin.package:
     name: "{{ tas_single_node_system_packages }}"
+    state: latest
 
 - name: Install Cockpit
   ansible.builtin.include_role:


### PR DESCRIPTION
We already ensure that we're running on RHEL 9.2, but that doesn't necessarily mean that the user has updated all packages. By using `state: latest` we ensure that new enough podman (and other deps) are of the required RHEL 9.2 versions.