### PR TITLE
Remove old hardcoded OIDC issuer

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -35,11 +35,7 @@ tas_single_node_tink_hcvault_token: ""
 
 tas_single_node_skip_os_install: false
 
-tas_single_node_oidc_issuers:
-  - issuer: https://keycloak-keycloak-system.apps.platform-sts.pcbk.p1.openshiftapps.com/auth/realms/trusted-artifact-signer
-    client_id: trusted-artifact-signer
-    url: https://keycloak-keycloak-system.apps.platform-sts.pcbk.p1.openshiftapps.com/auth/realms/trusted-artifact-signer
-    type: email
+tas_single_node_oidc_issuers: []
 
 tas_single_node_meta_issuers: []
 

--- a/roles/tas_single_node/tasks/main.yml
+++ b/roles/tas_single_node/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check OIDC issuers
+  ansible.builtin.fail:
+    msg: "Either tas_single_node_oidc_issuers or tas_single_node_meta_issuers must be specified"
+  when: not tas_single_node_oidc_issuers and not tas_single_node_meta_issuers
+
 - name: Check OS Support
   ansible.builtin.include_tasks: os_support.yml
 


### PR DESCRIPTION
This old hardcoded OIDC issuer was useful for testing, but we have it in the Molecule setup and it shouldn't be shipped to customers.