### PR TITLE
Remove hostPort definitions from all pods

### DIFF
--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -16,16 +16,13 @@
   register: remote_tuf_certificates
 
 - name: Retrieve Rekor Public Key
-  ansible.builtin.uri:
-    url: http://localhost:3001/api/v1/log/publicKey
-    method: GET
-    status_code: 200
-    validate_certs: false
-    return_content: true
-  until: rekor_public_key_result.status == 200
-  retries: "{{ tas_single_node_rekor_public_key_retries }}"
-  delay: "{{ tas_single_node_rekor_public_key_delay }}"
+  containers.podman.podman_container_exec:
+    name: rekor-server-pod-rekor-server
+    command: >-
+      curl -k --fail --retry {{ tas_single_node_rekor_public_key_retries }}
+      --retry-delay {{ tas_single_node_rekor_public_key_delay }} http://localhost:3001/api/v1/log/publicKey
   register: rekor_public_key_result
+  changed_when: false
 
 - name: Create tuf Secret
   ansible.builtin.copy:
@@ -45,7 +42,7 @@
         fulcio-cert: |
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}
         rekor-pubkey: |
-          {{ rekor_public_key_result.content | b64encode }}
+          {{ rekor_public_key_result.stdout | b64encode }}
         tsa-cert: |
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | first).content }}
   register: secret_result

--- a/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.yaml
+++ b/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.yaml
@@ -42,13 +42,10 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5555
-              hostPort: 5555
               protocol: TCP
             - containerPort: 5554
-              hostPort: 5554
               protocol: TCP
             - containerPort: 2113
-              hostPort: 2113
               protocol: TCP
           resources: {}
           volumeMounts:

--- a/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
@@ -41,7 +41,6 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6379
-              hostPort: 6379
               protocol: TCP
           readinessProbe:
             exec:

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -57,10 +57,8 @@ spec:
           ports:
             - containerPort: 3001
               protocol: TCP
-              hostPort: 3001
             - containerPort: 2112
               protocol: TCP
-              hostPort: 2112
           resources: {}
           volumeMounts:
             - mountPath: /sharding

--- a/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
+++ b/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
@@ -47,7 +47,6 @@ spec:
 {% endif %}
           ports:
             - containerPort: 3002
-              hostPort: 3002
               protocol: TCP
           resources: {}
           volumeMounts:


### PR DESCRIPTION
This removes hostPort definitions from all pods - everything that we want to expose should only be exposed through nginx right now. Anything else increases the surface for a potential attacker.

Included is a fix for one of the tasks that was relying on this to fetch the rekor public key.