### PR TITLE
Fix image build in molecule verify

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -12,10 +12,6 @@
       ansible.builtin.set_fact:
         node_ip: "{{ ansible_ssh_host }}"
 
-    - name: Debug
-      ansible.builtin.debug:
-        msg: "Test dir path is {{ test_dir_path }}"
-
     - name: Build the test Podman image
       containers.podman.podman_image:
         name: fedora-cosign

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -12,6 +12,10 @@
       ansible.builtin.set_fact:
         node_ip: "{{ ansible_ssh_host }}"
 
+    - name: Debug
+      ansible.builtin.debug:
+        msg: "Test dir path is {{ test_dir_path }}"
+
     - name: Build the test Podman image
       containers.podman.podman_image:
         name: fedora-cosign
@@ -21,7 +25,7 @@
         path: "{{ test_dir_path }}"
         build:
           cache: true
-          file: "Containerfile"
+          file: "{{ test_dir_path }}/Containerfile"
       become: false
       delegate_to: localhost
 


### PR DESCRIPTION
For some reason we now need to provide full path to the Containerfile. I'm honestly not sure why.