### PR TITLE
Drop hard dependency on collections.podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ The ingress host names are as follows, where `<base_hostname>` is your deploymen
   * Updated DNS records or `/etc/hosts` entries with the ingress host names and IP addresses.
 * Installation and configuration of Ansible on a control node to perform the automation.
 * Installation of the Ansible collections on the control node.
-  * If installing from the Ansible Automation Hub, then run `ansible-galaxy install redhat.artifact_signer`.
+  * Install the `containers.podman` collection from [Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/containers/podman/) by running `ansible-galaxy collection install "containers.podman>=1.15.0"`.
+  * If installing from the Ansible Automation Hub, then run `ansible-galaxy collection install redhat.artifact_signer`.
   * If installing from this Git repository, then clone it locally, and run `ansible-galaxy collection install -r requirements.yml`.
 * An OpenID Connect (OIDC) provider, such as [Keycloak](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/sso/).
 * The ability to resolve the ingress host names, by using the Domain Name System (DNS) or the `/etc/hosts` file.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,8 +16,7 @@ description: Install and configure RHTAS, a downstream redistribution of the Sig
 license_file: Apache-2.0
 tags: [sigstore, tas, rhtas, security, cosign]
 # NOTE: when updating, also update dependencies in requirements.yml
-dependencies:
-  containers.podman: ">=1.15.0"
+dependencies: {}
 repository: https://github.com/securesign/artifact-signer-ansible/
 documentation: http://TODO.com
 homepage: https://github.com/securesign/artifact-signer-ansible#rhtas-ansible-collection

--- a/molecule/requirements.yml
+++ b/molecule/requirements.yml
@@ -4,3 +4,4 @@
 
 collections:
   - community.crypto
+  - containers.podman

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,3 @@
 ---
 # NOTE: when updating, also update dependencies in galaxy.yml
-collections:
-  - name: containers.podman
-    version: ">=1.15.0"
+collections: []

--- a/roles/tas_single_node/meta/main.yml
+++ b/roles/tas_single_node/meta/main.yml
@@ -14,5 +14,4 @@ galaxy_info:
 
   galaxy_tags: [sigstore, tas, rhtas, security, cosign]
 
-collections:
-  - containers.podman
+collections: []


### PR DESCRIPTION
We can't have hard dependency on collections.podman as it is not on Ansible Automation Hub right now.