### PR TITLE
Implement usage of file signer for Rekor

### DIFF
--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -23,10 +23,11 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 | tas_single_node_rekor_public_key_retries | The number of attempts to retrieve the Rekor public key when constructing the trust root. | int |  `5`  |
 | tas_single_node_rekor_public_key_delay | The number of seconds to wait before retrying the retrieval of the Rekor public key when constructing the trust root. | int |  `10`  |
 | tas_single_node_setup_host_dns | Set up DNS on the managed host to resolve URLs of the configured RHTAS services. | bool |  `true`  |
-| tas_single_node_kms_key_resource | The Key Management Services (KMS) key for signing timestamp responses. Valid options are: [gcpkms://resource, azurekms://resource, hashivault://resource, awskms://resource]. | str |  |
-| tas_single_node_tink_key_resource | The KMS key for signing timestamp responses for Tink keysets. Valid options are: [gcp-kms://resource, aws-kms://resource, hcvault://]. | str |  |
-| tas_single_node_tsa_tink_keyset | The KMS-encrypted keyset for Tink that decrypts the tas_single_node_tink_key_resource string. | str |  |
-| tas_single_node_tink_hcvault_token | The authentication token for Hashicorp Vault API calls. | str |  |
+| tas_single_node_tsa_signer_type | Signer type to use for TSA. Valid options are: [file, kms, tink]. | str |  |
+| tas_single_node_tsa_kms_key_resource | The Key Management Services (KMS) key for signing timestamp responses. Valid options are: [gcpkms://resource, azurekms://resource, hashivault://resource, awskms://resource]. | str |  |
+| tas_single_node_tsa_tink_key_resource | The KMS key for signing timestamp responses for Tink keysets. Valid options are: [gcp-kms://resource, aws-kms://resource, hcvault://]. | str |  |
+| tas_single_node_tsa_tink_keyset | The KMS-encrypted keyset for Tink that decrypts the tas_single_node_tsa_tink_key_resource string. | str |  |
+| tas_single_node_tsa_tink_hcvault_token | The authentication token for Hashicorp Vault API calls. | str |  |
 | tas_single_node_skip_os_install | Whether or not to skip the installation of the required operating system packages. Only use this option when all packages are already installed at the versions released for RHEL 9.2 or later. | bool |  `false`  |
 | tas_single_node_meta_issuers | The list of OIDC meta issuers allowed to authenticate Fulcio certificate requests. | list of dicts of 'tas_single_node_meta_issuers' options |  |
 | tas_single_node_fulcio_server_image | Fulcio image | str |  `registry.redhat.io/rhtas/fulcio-rhel9@sha256:67495de82e2fcd2ab4ad0e53442884c392da1aa3f5dd56d9488a1ed5df97f513`  |

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -28,10 +28,11 @@ tas_single_node_rekor_public_key_delay: 10
 tas_single_node_setup_host_dns: true
 tas_single_node_base_hostname: ""
 
-tas_single_node_kms_key_resource: ""
-tas_single_node_tink_key_resource: ""
+tas_single_node_tsa_signer_type: file
+tas_single_node_tsa_kms_key_resource: ""
+tas_single_node_tsa_tink_key_resource: ""
 tas_single_node_tsa_tink_keyset: ""
-tas_single_node_tink_hcvault_token: ""
+tas_single_node_tsa_tink_hcvault_token: ""
 
 tas_single_node_skip_os_install: false
 

--- a/roles/tas_single_node/meta/argument_specs.yml
+++ b/roles/tas_single_node/meta/argument_specs.yml
@@ -143,8 +143,14 @@ argument_specs:
         type: "str"
         required: true
         version_added: "1.1.0"
-        # we provide no default value here intentionally
-      tas_single_node_kms_key_resource:
+        # we provide no default value here intentionall
+      tas_single_node_tsa_signer_type:
+        description: >
+          Signer type to use for TSA. Valid options are: [file, kms, tink].
+        type: str
+        required: false
+        version_added: "1.1.0"
+      tas_single_node_tsa_kms_key_resource:
         description: >
           The Key Management Services (KMS) key for signing timestamp responses.
           Valid options are: [gcpkms://resource, azurekms://resource, hashivault://resource, awskms://resource].
@@ -152,7 +158,7 @@ argument_specs:
         required: false
         version_added: "1.1.0"
         default: ""
-      tas_single_node_tink_key_resource:
+      tas_single_node_tsa_tink_key_resource:
         description: >
           The KMS key for signing timestamp responses for Tink keysets.
           Valid options are: [gcp-kms://resource, aws-kms://resource, hcvault://].
@@ -161,12 +167,12 @@ argument_specs:
         version_added: "1.1.0"
         default: ""
       tas_single_node_tsa_tink_keyset:
-        description: "The KMS-encrypted keyset for Tink that decrypts the tas_single_node_tink_key_resource string."
+        description: "The KMS-encrypted keyset for Tink that decrypts the tas_single_node_tsa_tink_key_resource string."
         type: "str"
         required: false
         version_added: "1.1.0"
         default: ""
-      tas_single_node_tink_hcvault_token:
+      tas_single_node_tsa_tink_hcvault_token:
         description: "The authentication token for Hashicorp Vault API calls."
         type: "str"
         required: false

--- a/roles/tas_single_node/tasks/certificates.yml
+++ b/roles/tas_single_node/tasks/certificates.yml
@@ -150,6 +150,31 @@
           -passin 'pass:{{ tas_single_node_ctlog_ca_passphrase }}'
         creates: "{{ tas_single_node_remote_ctlog_public_key }}"
 
+- name: Create Rekor signing key
+  when: >
+    (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_rekor_private_key) | list | length) == 0
+    or (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_rekor_public_key) | list | length) == 0
+    and tas_single_node_rekor_signer_type == 'file'
+
+  block:
+    - name: Create Rekor private key
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail &&
+          openssl ecparam -genkey -name prime256v1 |
+          openssl ec -des3
+          -out '{{ tas_single_node_remote_rekor_private_key }}'
+          -passout 'pass:{{ tas_single_node_rekor_ca_passphrase }}'
+        creates: "{{ tas_single_node_remote_rekor_private_key }}"
+    - name: Create Rekor public key
+      ansible.builtin.command:
+        cmd: >-
+          openssl ec -pubout
+          -in '{{ tas_single_node_remote_rekor_private_key }}'
+          -out '{{ tas_single_node_remote_rekor_public_key }}'
+          -passin 'pass:{{ tas_single_node_rekor_ca_passphrase }}'
+        creates: "{{ tas_single_node_remote_rekor_public_key }}"
+
 - name: Handle TSA certificate chain
   block:
     - name: Create TSA root private key
@@ -164,7 +189,7 @@
       when: >
         (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_private_key) | list | length) == 0
         and (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
-        and tas_single_node_signer_type == 'file'
+        and tas_single_node_tsa_signer_type == 'file'
 
     - name: Create certificate signing request (CSR) for TSA root certificate
       ansible.builtin.command:
@@ -178,7 +203,7 @@
       register: tsa_root_csr
       when: >
         (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
-        and tas_single_node_signer_type == 'file'
+        and tas_single_node_tsa_signer_type == 'file'
       changed_when: false
 
     - name: Create self-signed TSA root CA from CSR
@@ -195,7 +220,7 @@
         creates: "{{ tas_single_node_remote_tsa_certificate_chain }}"
       when: >
         (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
-        and tas_single_node_signer_type == 'file'
+        and tas_single_node_tsa_signer_type == 'file'
 
     # Leaf certificate
     - name: Create TSA leaf CA private key
@@ -210,7 +235,7 @@
       when: >
         (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
         and (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_signer_private_key) | list | length) == 0
-        and tas_single_node_signer_type == 'file'
+        and tas_single_node_tsa_signer_type == 'file'
 
     - name: Create TSA leaf CSR
       ansible.builtin.command:
@@ -225,7 +250,7 @@
       register: tsa_leaf_csr
       when: >
         (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
-        and tas_single_node_signer_type == 'file'
+        and tas_single_node_tsa_signer_type == 'file'
       changed_when: false
 
     - name: Sign leaf certificate with Root CA
@@ -243,7 +268,7 @@
         creates: "{{ tas_single_node_remote_tsa_leaf_certificate }}"
       when: >
         (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
-        and tas_single_node_signer_type == 'file'
+        and tas_single_node_tsa_signer_type == 'file'
 
 
     - name: Create temporary directory for manipulating CA certificate chain
@@ -262,7 +287,7 @@
       changed_when: "'changed' in result.stdout"
       when: >
         (certs_dir_files.files | selectattr('path', 'equalto', tas_single_node_remote_tsa_certificate_chain) | list | length) == 0
-        and tas_single_node_signer_type == 'file'
+        and tas_single_node_tsa_signer_type == 'file'
 
     - name: Delete content & directory
       ansible.builtin.file:

--- a/roles/tas_single_node/tasks/configuration_check.yml
+++ b/roles/tas_single_node/tasks/configuration_check.yml
@@ -1,0 +1,15 @@
+---
+- name: Check OIDC issuers
+  ansible.builtin.fail:
+    msg: "Either tas_single_node_oidc_issuers or tas_single_node_meta_issuers must be specified"
+  when: not tas_single_node_oidc_issuers and not tas_single_node_meta_issuers
+
+- name: Prevent usage of memory signer for TSA
+  ansible.builtin.fail:
+    msg: "'memory' signer can't be used for TSA"
+  when: tas_single_node_tsa_signer_type == "memory"
+
+- name: Prevent usage of memory signer for Rekor
+  ansible.builtin.fail:
+    msg: "'memory' signer can't be used for Rekor"
+  when: tas_single_node_rekor_signer_type == "memory"

--- a/roles/tas_single_node/tasks/main.yml
+++ b/roles/tas_single_node/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
-- name: Check OIDC issuers
-  ansible.builtin.fail:
-    msg: "Either tas_single_node_oidc_issuers or tas_single_node_meta_issuers must be specified"
-  when: not tas_single_node_oidc_issuers and not tas_single_node_meta_issuers
+- name: Check configuration correctness
+  ansible.builtin.include_tasks: configuration_check.yml
 
 - name: Check OS Support
   ansible.builtin.include_tasks: os_support.yml

--- a/roles/tas_single_node/tasks/podman/rekor.yml
+++ b/roles/tas_single_node/tasks/podman/rekor.yml
@@ -5,18 +5,45 @@
 - name: Create Rekor Sharding ConfigMap
   ansible.builtin.copy:
     content: "{{ configmap_content | to_nice_yaml(indent=2) }}"
-    dest: "{{ tas_single_node_rekor_sharding_config }}"
+    dest: "{{ tas_single_node_rekor_server_config }}"
     mode: "0600"
   vars:
     configmap_content:
       kind: ConfigMap
       apiVersion: v1
       metadata:
-        name: rekor-sharding-config
+        name: rekor-server-config
         namespace: rekor-system
       data:
         sharding-config.yaml: ""
   register: configmap_result
+
+- name: Slurp Rekor keys
+  ansible.builtin.slurp:
+    src: "{{ item }}"
+  loop:
+    - "{{ tas_single_node_remote_rekor_private_key }}"
+    - "{{ tas_single_node_remote_rekor_public_key }}"
+  register: remote_rekor_keys
+
+- name: Create Rekor secret
+  ansible.builtin.copy:
+    content: "{{ secret_content | to_nice_yaml(indent=2) }}"
+    dest: "{{ tas_single_node_rekor_secret }}"
+    mode: "0600"
+  vars:
+    secret_content:
+      kind: Secret
+      apiVersion: v1
+      metadata:
+        name: rekor-secret
+        namespace: rekor-system
+      data:
+        private: |
+          {{ (remote_rekor_keys.results | selectattr('source', 'equalto', tas_single_node_remote_rekor_private_key) | list | first).content }}
+        public: |
+          {{ (remote_rekor_keys.results | selectattr('source', 'equalto', tas_single_node_remote_rekor_public_key) | list | first).content }}
+  register: secret_result
 
 - name: Deploy Rekor Redis Pod
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -36,5 +63,7 @@
       systemd_file: rekor
       network: "{{ tas_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/rekor-server.j2') | from_yaml }}"
-      configmap: "{{ tas_single_node_rekor_sharding_config }}"
+      configmap: "{{ tas_single_node_rekor_server_config }}"
       configmap_changed: "{{ configmap_result.changed }}"
+      secret: "{{ tas_single_node_rekor_secret }}"
+      secret_changed: "{{ secret_result.changed }}"

--- a/roles/tas_single_node/tasks/podman/tsa.yml
+++ b/roles/tas_single_node/tasks/podman/tsa.yml
@@ -27,7 +27,7 @@
 - name: Append Tink secret data
   ansible.builtin.set_fact:
     secret_data: "{{ secret_data | combine({'encrypted_key_set': tas_single_node_tsa_tink_keyset | b64encode}) }}"
-  when: tas_single_node_signer_type == 'tink'
+  when: tas_single_node_tsa_signer_type == 'tink'
 
 - name: Create TSA Secret
   ansible.builtin.copy:

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -39,14 +39,17 @@ spec:
             - serve
             - --trillian_log_server.address=trillian-logserver-pod
             - --trillian_log_server.port=8091
-            - --trillian_log_server.sharding_config=/sharding/sharding-config.yaml
+            - --trillian_log_server.sharding_config=/config/sharding-config.yaml
             - --redis_server.address={{ tas_single_node_rekor_redis.redis.host }}
             - --redis_server.port={{ tas_single_node_rekor_redis.redis.port }}
 {% if tas_single_node_rekor_redis.redis.password != "" %}
             - --redis_server.password={{ tas_single_node_rekor_redis.redis.password }}
 {% endif %}
             - --rekor_server.address=0.0.0.0
-            - --rekor_server.signer=memory
+{% if tas_single_node_rekor_signer_type == "file" %}
+            - --rekor_server.signer=/rekor-keys/private
+            - --rekor_server.signer-passwd={{ tas_single_node_rekor_ca_passphrase }}
+{% endif %}
             - --enable_retrieve_api=true
             - --trillian_log_server.tlog_id={{ trillian_tree_id }}
             - --enable_attestation_storage
@@ -61,16 +64,21 @@ spec:
               protocol: TCP
           resources: {}
           volumeMounts:
-            - mountPath: /sharding
-              name: rekor-sharding-config
+            - mountPath: /rekor-keys
+              name: keys
+            - mountPath: /config
+              name: rekor-server-config
             - mountPath: /var/run/attestations
               name: storage
       restartPolicy: Always
       volumes:
-        - name: rekor-sharding-config
+        - name: keys
+          secret:
+            secretName: rekor-secret
+        - name: rekor-server-config
           configMap:
             defaultMode: 420
-            name: rekor-sharding-config
+            name: rekor-server-config
         - name: storage
           persistentVolumeClaim:
             claimName: rekor-server

--- a/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
+++ b/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
@@ -32,18 +32,18 @@ spec:
             - "--host=0.0.0.0"
             - "--port=3002"
             - "--certificate-chain-path=/etc/secrets/cert_chain/certificate-chain.pem"
-            - "--timestamp-signer={{ tas_single_node_signer_type }}"
-{% if tas_single_node_signer_type == 'file' %}
+            - "--timestamp-signer={{ tas_single_node_tsa_signer_type }}"
+{% if tas_single_node_tsa_signer_type == 'file' %}
             - "--file-signer-key-path=/etc/secrets/keys/private_key.pem"
             - "--file-signer-passwd={{ tas_single_node_tsa_signer_passphrase }}"
 {% endif %}
-{% if tas_single_node_signer_type == 'kms' %}
-            - '--kms-key-resource={{ tas_single_node_kms_key_resource }}"
+{% if tas_single_node_tsa_signer_type == 'kms' %}
+            - '--kms-key-resource={{ tas_single_node_tsa_kms_key_resource }}"
 {% endif %}
-{% if tas_single_node_signer_type == 'tink' %}
-            - '--tink-key-resource={{ tas_single_node_tink_key_resource }}"
+{% if tas_single_node_tsa_signer_type == 'tink' %}
+            - '--tink-key-resource={{ tas_single_node_tsa_tink_key_resource }}"
             - '--tink-keyset-path=/etc/secrets/keys/encrypted_key_set"
-            - '--tink-hcvault-token={{ tas_single_node_tink_hcvault_token }}"
+            - '--tink-hcvault-token={{ tas_single_node_tsa_tink_hcvault_token }}"
 {% endif %}
           ports:
             - containerPort: 3002
@@ -53,12 +53,12 @@ spec:
             - name: tsa-cert-chain
               mountPath: /etc/secrets/cert_chain
               readOnly: true
-{% if tas_single_node_signer_type == 'file' %}
+{% if tas_single_node_tsa_signer_type == 'file' %}
             - name: tsa-file-signer-config
               mountPath: /etc/secrets/keys
               readOnly: true
 {% endif %}
-{% if tas_single_node_signer_type == 'tink' %}
+{% if tas_single_node_tsa_signer_type == 'tink' %}
             - name: tsa-file-signer-config
               mountPath: /etc/secrets/keys
               readOnly: true
@@ -86,7 +86,7 @@ spec:
             items:
               - key: certificate-chain.pem
                 path: certificate-chain.pem
-{% if tas_single_node_signer_type == 'file' %}
+{% if tas_single_node_tsa_signer_type == 'file' %}
         - name: tsa-file-signer-config
           secret:
             secretName: tsa-server-secret
@@ -94,7 +94,7 @@ spec:
               - key: private_key.pem
                 path: private_key.pem
 {% endif %}
-{% if tas_single_node_signer_type == 'tink' %}
+{% if tas_single_node_tsa_signer_type == 'tink' %}
         - name: tsa-file-signer-config
           secret:
             secretName: tsa-server-secret

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -13,6 +13,7 @@ tas_single_node_cockpit:
     - cockpit
   cockpit_manage_firewall: true
 
+tas_single_node_rekor_signer_type: file # to be exposed to users later on
 tas_single_node_rekor_templates:
   - manifests/rekor/redis-server.j2
   - manifests/rekor/rekor-server.j2
@@ -40,7 +41,7 @@ tas_single_node_remote_fulcio_public_key: "{{ tas_single_node_certs_dir }}/{{ ta
 tas_single_node_remote_fulcio_root_ca: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_fulcio_root_ca_filename }}"
 tas_single_node_remote_ctlog_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_ctlog_private_key_filename }}"
 tas_single_node_remote_ctlog_public_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_ctlog_public_key_filename }}"
-tas_single_node_remote_rekor_signer: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_rekor_signer_filename }}"
+tas_single_node_remote_rekor_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_rekor_signer_filename }}"
 tas_single_node_remote_rekor_public_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_rekor_public_key_filename }}"
 
 # Cert Passphrases
@@ -73,7 +74,8 @@ tas_single_node_ctlog_secret: "{{ tas_single_node_kube_configmap_dir }}/ctlog-se
 tas_single_node_ctlog_configmap_config: "{{ tas_single_node_kube_configmap_dir }}/ctlog-config.yaml"
 tas_single_node_tuf_secret_config: "{{ tas_single_node_kube_configmap_dir }}/tuf-secret.yaml"
 tas_single_node_treeid_config: "{{ tas_single_node_kube_configmap_dir }}/treeid-config.yaml"
-tas_single_node_rekor_sharding_config: "{{ tas_single_node_kube_configmap_dir }}/rekor-sharding-config.yaml"
+tas_single_node_rekor_secret: "{{ tas_single_node_kube_configmap_dir }}/rekor-secret.yaml"
+tas_single_node_rekor_server_config: "{{ tas_single_node_kube_configmap_dir }}/rekor-server-config.yaml"
 tas_single_node_nginx_config: "{{ tas_single_node_kube_configmap_dir }}/nginx-config.yaml"
 tas_single_node_nginx_certs_config: "{{ tas_single_node_kube_configmap_dir }}/nginx-certs.yaml"
 tas_single_node_trillian_secret: "{{ tas_single_node_kube_configmap_dir }}/trillian-secret.yaml"
@@ -81,7 +83,6 @@ tas_single_node_tsa_secret: "{{ tas_single_node_kube_configmap_dir }}/tsa-secret
 tas_single_node_systemd_directory: /etc/systemd/system
 
 # Timestamp Authority Config
-tas_single_node_signer_type: file
 tas_single_node_remote_tsa_signer_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_signer_private_key_filename }}"
 tas_single_node_remote_tsa_leaf_certificate: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_leaf_certificate_filename }}"
 tas_single_node_remote_tsa_certificate_chain: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_certificate_chain_filename }}"


### PR DESCRIPTION
This replaces the `memory` signer with a `file` signer for Rekor. It also prohibits usage of `memory` signer for now (not useful ATM) and renames some TSA-related variables so it's clear they're meant for TSA.