### PR TITLE
Drop usage of containers.podman collection

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,5 @@
 ---
 exclude_paths:
   - .github
+  - molecule
   - vm-testing

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,8 +16,7 @@ description: Install and configure RHTAS, a downstream redistribution of the Sig
 license_file: Apache-2.0
 tags: [sigstore, tas, rhtas, security, cosign]
 # NOTE: when updating, also update dependencies in requirements.yml
-dependencies:
-  containers.podman: ">=1.15.0"
+dependencies: {}
 repository: https://github.com/securesign/artifact-signer-ansible/
 documentation: http://TODO.com
 homepage: https://github.com/securesign/artifact-signer-ansible#rhtas-ansible-collection

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,3 @@
 ---
 # NOTE: when updating, also update dependencies in galaxy.yml
-collections:
-  - name: containers.podman
-    version: ">=1.15.0"
+collections: []

--- a/roles/tas_single_node/meta/main.yml
+++ b/roles/tas_single_node/meta/main.yml
@@ -14,5 +14,4 @@ galaxy_info:
 
   galaxy_tags: [sigstore, tas, rhtas, security, cosign]
 
-collections:
-  - containers.podman
+collections: []

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -1,7 +1,16 @@
 ---
+- name: Check if RHTAS network exists
+  ansible.builtin.command:
+    cmd: "podman network inspect {{ tas_single_node_podman_network }}"
+  register: network_inspect_result
+  failed_when: false
+  changed_when: false
+
 - name: Create RHTAS network
-  containers.podman.podman_network:
-    name: "{{ tas_single_node_podman_network }}"
+  ansible.builtin.command:
+    cmd: "podman network create {{ tas_single_node_podman_network }}"
+  when: network_inspect_result.rc != 0
+  changed_when: true
 
 - name: Create Manifests/Configs Directory
   ansible.builtin.file:
@@ -25,8 +34,8 @@
   changed_when: true
 
 - name: Pull all images
-  containers.podman.podman_image:
-    name: "{{ item }}"
+  ansible.builtin.command:
+    cmd: "podman pull {{ item }}"
   vars:
     enabled_vals: [
       "{{ tas_single_node_fulcio_enabled }}",
@@ -60,6 +69,14 @@
   loop_control:
     index_var: idx
   when: enabled_vals[idx] | bool
+  changed_when: false
+  # NOTE: there's no way to tell if "podman pull" actually changed something;
+  # we also can't be 100 % certain if the required image is pulled before pulling,
+  # because the user might use a tag instead of of digest and hence we need to try
+  # pulling again anyway. Podman output doesn't tell us if the image already existed
+  # or not: https://github.com/containers/podman/issues/13582
+  # Hence, we just set changed_when: false, which is fine because we're not using
+  # the result of this task anywhere.
 
 - name: Configure/Deploy nginx
   ansible.builtin.include_tasks: podman/nginx.yml

--- a/roles/tas_single_node/tasks/podman/createtree.yml
+++ b/roles/tas_single_node/tasks/podman/createtree.yml
@@ -21,18 +21,22 @@
 - name: Create Tree ID
   when: trillian_tree_id is not defined or not treeid_config_stat.stat.exists
   block:
+    - name: Generate unique container name for the createtree container
+      ansible.builtin.set_fact:
+        createtree_container_name: "{{ lookup('password', '/dev/null length=20 chars=ascii_letters') }}"
+
     - name: Createtree container
-      containers.podman.podman_container:
-        name: createtree
-        image: "{{ tas_single_node_create_tree_image }}"
-        command: --admin_server trillian-logserver-pod:8091
-        network: "{{ tas_single_node_podman_network }}"
-        detach: false
+      ansible.builtin.command:
+        cmd: >-
+          podman run --network {{ tas_single_node_podman_network }} --replace
+          --name {{ createtree_container_name }} {{ tas_single_node_create_tree_image }}
+          --admin_server trillian-logserver-pod:8091
       register: createtree_container
+      changed_when: true
 
     - name: Obtain Createtree logs
       ansible.builtin.command:
-        cmd: podman logs {{ createtree_container.container.Id }}
+        cmd: "podman logs {{ createtree_container_name }}"
       register: createtree_container_logs
       changed_when: false
 
@@ -41,9 +45,9 @@
         trillian_tree_id: "{{ createtree_container_logs.stdout_lines[0] }}"
 
     - name: Remove createtree container
-      containers.podman.podman_container:
-        name: createtree
-        state: absent
+      ansible.builtin.command:
+        cmd: "podman rm {{ createtree_container_name }}"
+      changed_when: true
 
     - name: Create Trillian treeid ConfigMap
       ansible.builtin.copy:

--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -16,14 +16,14 @@
   register: copy_manifest
 
 - name: Create Secret
+  # Note for when we'll use containers.podman.podman_play:
   # We can't use podman_secret because we support Podman 4.4.1 and the podman_secret module only
   # supports idempotency with >= 4.7.0: https://github.com/containers/ansible-podman-collections/issues/692
   # Unfortunately podman_play doesn't properly understand idempotency with secrets either
   # The next best thing is to identify whether the secret file changed - this is determined from the secret_changed
   # variable passed by the caller to this file
-  containers.podman.podman_play:
-    kube_file: "{{ podman_spec.secret }}"
-    state: "{{ podman_spec.state | default('started') }}"
+  ansible.builtin.command:
+    cmd: "podman kube play {{ podman_spec.secret }}"
   when: podman_spec.secret is defined
   changed_when: podman_spec.secret is defined and podman_spec.secret_changed
 

--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -7,13 +7,14 @@
     msg: "'tas_single_node_base_hostname' must be specified"
 
 - name: Get RHTAS network details
-  containers.podman.podman_network:
-    name: "{{ tas_single_node_podman_network }}"
+  ansible.builtin.command:
+    cmd: "podman network inspect {{ tas_single_node_podman_network }}"
   register: tas_podman_network_results
+  changed_when: false
 
 - name: Set DNS Resolver
   ansible.builtin.set_fact:
-    dns_resolver: "{{ tas_podman_network_results.network.subnets[0].gateway }}"
+    dns_resolver: "{{ (tas_podman_network_results.stdout | from_json)[0].subnets[0].gateway }}"
 
 - name: Slurp ingress Certificates
   ansible.builtin.slurp:

--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -16,9 +16,9 @@
   register: remote_tuf_certificates
 
 - name: Retrieve Rekor Public Key
-  containers.podman.podman_container_exec:
-    name: rekor-server-pod-rekor-server
-    command: >-
+  ansible.builtin.command:
+    cmd: >-
+      podman exec rekor-server-pod-rekor-server
       curl -k --fail --retry {{ tas_single_node_rekor_public_key_retries }}
       --retry-delay {{ tas_single_node_rekor_public_key_delay }} http://localhost:3001/api/v1/log/publicKey
   register: rekor_public_key_result


### PR DESCRIPTION
Because the containers.podman collection dependency would make our collection ineligible for certification on Ansible Automation Hub, we need to completely drop it. This PR replaces #53.