### PR TITLE
Test using galaxy-importer, fix metadata

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,10 +1,10 @@
-name: Run ansible-lint
+name: Run linters (ansible-lint, antsibull-docs, galaxy-importer)
 on:
   push:
   pull_request:
 
 jobs:
-  ansible-lint:
+  run-linters:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout code
@@ -17,6 +17,7 @@ jobs:
             # we also lint the molecule setup
             ansible-galaxy install -r molecule/requirements.yml
             make lint
+            make galaxy-importer-test
             # ensure that the role README was regenerated
             make role-readme
             if ! git diff --exit-code roles/tas_single_node/README.md; then

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ context/
 *+00:00.json
 *.swp
 .vscode/
+importer_result.json
 redhat-artifact_signer-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ lint:
 	ansible-lint
 	antsibull-docs lint-collection-docs --plugin-docs --skip-rstcheck .
 
+galaxy-importer-test:
+	ansible-galaxy collection build --force
+	python -m galaxy_importer.main redhat-artifact_signer-*.tar.gz
+
 role-readme: galaxy.yml roles/tas_single_node/README.j2 roles/tas_single_node/meta/argument_specs.yml roles/tas_single_node/meta/main.yml
 	# Trying to put aar_doc in testing-requirements.txt leads to dependency hell,
 	# but if we install it in with other tools from testing-requirements.txt, it works fine

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,13 +13,13 @@ authors:
   - Tommy Dalton <tdalton@redhat.com>
   - Aleksy Siek <asiek@redhat.com>
 description: Install and configure RHTAS, a downstream redistribution of the Sigstore project.
-license_file: Apache-2.0
+license_file: LICENSE
 tags: [sigstore, tas, rhtas, security, cosign]
 # NOTE: when updating, also update dependencies in requirements.yml
 dependencies:
   containers.podman: ">=1.15.0"
 repository: https://github.com/securesign/artifact-signer-ansible/
-documentation: http://TODO.com
+documentation: https://docs.redhat.com/en/documentation/red_hat_trusted_artifact_signer
 homepage: https://github.com/securesign/artifact-signer-ansible#rhtas-ansible-collection
 issues: https://github.com/securesign/artifact-signer-ansible/issues
 

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,5 +1,6 @@
 ansible-lint==24.6.1
 antsibull-docs==2.13.1
+galaxy-importer==0.4.25
 molecule==24.7.0
 # testing farm should depend on setuptools, but it doesn't; list them here explicitly
 setuptools==72.1.0


### PR DESCRIPTION
This PR adds a test using galaxy-importer to ensure we are always ready for import to Ansible Automation Hub. It also fixes the rest of the metadata to ensure that the import passes.