### PR TITLE
Properly template rekor URL in rekor-search configuration

### DIFF
--- a/molecule/requirements.yml
+++ b/molecule/requirements.yml
@@ -4,3 +4,4 @@
 
 collections:
   - community.crypto
+  - containers.podman

--- a/roles/tas_single_node/templates/manifests/rekor-search-ui/rekor-search-ui.yml
+++ b/roles/tas_single_node/templates/manifests/rekor-search-ui/rekor-search-ui.yml
@@ -30,7 +30,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
-              value: https://rekor.myrhtas
+              value: https://rekor.{{ tas_single_node_base_hostname }}
           ports:
             - containerPort: 3000
               protocol: TCP


### PR DESCRIPTION
This was missed in the original review #10. The URL needs to be templated so that rekor-search UI properly points to the deployed rekor.