### PR TITLE
Template out url and port of DB for trillian initContainers

### DIFF
--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.yaml
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.yaml
@@ -64,7 +64,7 @@ spec:
         - name: wait-for-trillian-db
           image: "{{ tas_single_node_trillian_netcat_image }}"
           imagePullPolicy: IfNotPresent
-          command: ["sh", "-c", "until nc -z -w 10 trillian-mysql-pod 3306; do echo waiting for trillian-mysql; sleep 5; done;"]
+          command: ["sh", "-c", "until nc -z -w 10 {{ tas_single_node_trillian.mysql.host }} {{ tas_single_node_trillian.mysql.port }}; do echo waiting for trillian-mysql; sleep 5; done;"]
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.yaml
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.yaml
@@ -28,7 +28,7 @@ spec:
         - name: wait-for-trillian-db
           image: "{{ tas_single_node_trillian_netcat_image}}"
           imagePullPolicy: IfNotPresent
-          command: ["sh", "-c", "until nc -z -w 10 trillian-mysql-pod 3306; do echo waiting for trillian-mysql-pod; sleep 5; done;"]
+          command: ["sh", "-c", "until nc -z -w 10 {{ tas_single_node_trillian.mysql.host }} {{ tas_single_node_trillian.mysql.port }}; do echo waiting for trillian mysql; sleep 5; done;"]
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File


### PR DESCRIPTION
Previously these values weren't templated, so using a BYODB instance would result in trillian not starting at all.