### PR TITLE
Ensure test fails if TSA cert is not distributed through TUF

### DIFF
--- a/vm-testing/test/test-sign-blob.sh
+++ b/vm-testing/test/test-sign-blob.sh
@@ -40,5 +40,4 @@ echo "testing" > to-sign
 
 cosign --verbose sign-blob to-sign --bundle signed.bundle --identity-token="${TOKEN}" --timestamp-server-url="${COSIGN_TSA_URL}" --rfc3161-timestamp=timestamp.txt
 
-curl "${COSIGN_TSA_URL}"/certchain > tsa_chain.pem
-cosign --verbose verify-blob --certificate-identity="${USERNAME}"@redhat.com --bundle signed.bundle to-sign --timestamp-certificate-chain=tsa_chain.pem --rfc3161-timestamp=timestamp.txt
+cosign --verbose verify-blob --certificate-identity="${USERNAME}"@redhat.com --bundle signed.bundle to-sign --rfc3161-timestamp=timestamp.txt --use-signed-timestamps


### PR DESCRIPTION
By passing `--use-signed-timestamps` instead of explicitly providing the TSA cert chain, we verify that cosign got the TSA cert chain through TUF.