### PR TITLE
Don't log the podman login command to prevent displaying the password

### DIFF
--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -32,6 +32,7 @@
   register: podman_login_result
   when: logincheck.stdout | string != tas_single_node_registry_username | string
   changed_when: true
+  no_log: true
 
 - name: Pull all images
   ansible.builtin.command:


### PR DESCRIPTION
This ensures that the registry password doesn't get printed with verbose output.