### PR TITLE
Updating manifests 

### DIFF
--- a/roles/tas_single_node/templates/manifests/cli-server/cli-server.j2
+++ b/roles/tas_single_node/templates/manifests/cli-server/cli-server.j2
@@ -4,20 +4,20 @@ metadata:
   name: "{{ tas_single_node_cli_server_pod }}"
   namespace: cli-server
   labels:
-    app.kubernetes.io/component: client-server
+    app.podman.io/component: client-server
     app.name: client-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: client-server
-      app.kubernetes.io/part-of: trusted-artifact-signer
+      app.podman.io/component: client-server
+      app.podman.io/part-of: trusted-artifact-signer
       app.name: client-server
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: client-server
-        app.kubernetes.io/part-of: trusted-artifact-signer
+        app.podman.io/component: client-server
+        app.podman.io/part-of: trusted-artifact-signer
         app.name: client-server
     spec:
       containers:

--- a/roles/tas_single_node/templates/manifests/cli-server/cli-server.j2
+++ b/roles/tas_single_node/templates/manifests/cli-server/cli-server.j2
@@ -4,34 +4,53 @@ metadata:
   name: "{{ tas_single_node_cli_server_pod }}"
   namespace: cli-server
   labels:
-    app.instance: scaffold
-    app.name: cli-server
+    app.kubernetes.io/component: client-server
+    app.name: client-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.component: cli-server
-      app.instance: scaffold
-      app.name: cli-server
+      app.kubernetes.io/component: client-server
+      app.kubernetes.io/part-of: trusted-artifact-signer
+      app.name: client-server
   template:
     metadata:
       labels:
-        app.component: cli-server
-        app.instance: scaffold
-        app.name: cli-server
+        app.kubernetes.io/component: client-server
+        app.kubernetes.io/part-of: trusted-artifact-signer
+        app.name: client-server
     spec:
       containers:
-        - name: cli-server
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          name: cli-server
           image: "{{ tas_single_node_client_server_image }}"
-          imagePullPolicy: Always
+          terminationMessagePolicy: File
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 65533
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: {{ tas_single_node_cli_server_port_http }}
               protocol: TCP
+          imagePullPolicy: Always
           volumeMounts:
             - name: apache-config
               mountPath: /var/www/html/index.html
               subPath: index.html
       restartPolicy: Always
+      tolerations:
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
       volumes:
         - name: apache-config
           configMap:

--- a/roles/tas_single_node/templates/manifests/ctlog/ctlog.j2
+++ b/roles/tas_single_node/templates/manifests/ctlog/ctlog.j2
@@ -4,8 +4,9 @@ metadata:
   name: "{{ tas_single_node_ctlog_pod }}"
   namespace: ctlog-system
   labels:
-    app.instance: scaffold
+    app.kubernetes.io/component: ctlog
     app.name: ctlog
+    app.kubernetes.io/part-of: trusted-artifact-signer
 spec:
   replicas: 1
   selector:
@@ -15,13 +16,24 @@ spec:
     metadata:
       labels:
         app: ctlog
-        app.instance: scaffold
+        app.kubernetes.io/component: ctlog
         app.name: ctlog
+        app.kubernetes.io/part-of: trusted-artifact-signer
     spec:
       containers:
         - name: ctlog
           image: "{{ tas_single_node_ctlog_image }}"
           imagePullPolicy: IfNotPresent
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: {{ tas_single_node_ctlog_port_http }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           livelinessProbe:
             failureThreshold: 3
             httpGet:
@@ -62,6 +74,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65533
+        allowPrivilegeEscalation: false
       serviceAccountName: ctlog
       tolerations:
         - effect: NoExecute
@@ -76,6 +89,7 @@ spec:
         - name: keys
           secret:
             secretName: ctlog-secret
+            defaultMode: 420
         - name: config
           configMap:
             name: ctlog-config

--- a/roles/tas_single_node/templates/manifests/ctlog/ctlog.j2
+++ b/roles/tas_single_node/templates/manifests/ctlog/ctlog.j2
@@ -4,9 +4,9 @@ metadata:
   name: "{{ tas_single_node_ctlog_pod }}"
   namespace: ctlog-system
   labels:
-    app.kubernetes.io/component: ctlog
+    app.podman.io/component: ctlog
     app.name: ctlog
-    app.kubernetes.io/part-of: trusted-artifact-signer
+    app.podman.io/part-of: trusted-artifact-signer
 spec:
   replicas: 1
   selector:
@@ -16,9 +16,9 @@ spec:
     metadata:
       labels:
         app: ctlog
-        app.kubernetes.io/component: ctlog
+        app.podman.io/component: ctlog
         app.name: ctlog
-        app.kubernetes.io/part-of: trusted-artifact-signer
+        app.podman.io/part-of: trusted-artifact-signer
     spec:
       containers:
         - name: ctlog

--- a/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.j2
+++ b/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.j2
@@ -37,7 +37,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           terminationMessagePath: /dev/termination-log
-          livelinessProbe:
+          livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /healthz

--- a/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.j2
+++ b/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.j2
@@ -4,10 +4,9 @@ metadata:
   name: "{{ tas_single_node_fulcio_pod }}"
   namespace: fulcio-system
   labels:
-    app.kubernetes.io/component: fulcio
-    app.kubernetes.io/part-of: trusted-artifact-signer
-    app.kubernetes.io/name: fulcio-server
-    pod-template-hash: 5d7c67b946
+    app.podman.io/component: fulcio-server
+    app.podman.io/part-of: trusted-artifact-signer
+    app.name: fulcio-server
 spec:
   replicas: 1
   selector:
@@ -17,10 +16,9 @@ spec:
     metadata:
       labels:
         app: fulcio-server
-        app.kubernetes.io/component: fulcio
-        app.kubernetes.io/name: fulcio
-        app.kubernetes.io/part-of: trusted-artifact-signer
-        pod-template-hash: 5d7c67b946
+        app.podman.io/component: fulcio
+        app.name: fulcio-server
+        app.podman.io/part-of: trusted-artifact-signer
     spec:
       automountServiceAccountToken: true
       priority: 0

--- a/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.j2
+++ b/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.j2
@@ -4,9 +4,10 @@ metadata:
   name: "{{ tas_single_node_fulcio_pod }}"
   namespace: fulcio-system
   labels:
-    app.instance: scaffold
-    app.name: fulcio
-    pod-template-hash: 74d5ff6f7f
+    app.kubernetes.io/component: fulcio
+    app.kubernetes.io/part-of: trusted-artifact-signer
+    app.kubernetes.io/name: fulcio-server
+    pod-template-hash: 5d7c67b946
 spec:
   replicas: 1
   selector:
@@ -16,13 +17,36 @@ spec:
     metadata:
       labels:
         app: fulcio-server
-        app.instance: scaffold
-        app.name: fulcio
-        pod-template-hash: 74d5ff6f7f
+        app.kubernetes.io/component: fulcio
+        app.kubernetes.io/name: fulcio
+        app.kubernetes.io/part-of: trusted-artifact-signer
+        pod-template-hash: 5d7c67b946
     spec:
       automountServiceAccountToken: true
+      priority: 0
       containers:
         - name: fulcio-server
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: {{ tas_single_node_fulcio_port_http }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          terminationMessagePath: /dev/termination-log
+          livelinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: {{ tas_single_node_fulcio_port_http }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           args:
             - serve
             - --port={{ tas_single_node_fulcio_port_http }}
@@ -63,6 +87,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65533
+        allowPrivilegeEscalation: false
       serviceAccountName: fulcio-server
       tolerations:
         - effect: NoExecute

--- a/roles/tas_single_node/templates/manifests/rekor-search-ui/rekor-search-ui.j2
+++ b/roles/tas_single_node/templates/manifests/rekor-search-ui/rekor-search-ui.j2
@@ -4,20 +4,20 @@ metadata:
   name: "{{ tas_single_node_rekor_search_ui_pod }}"
   namespace: rekor-search-ui
   labels:
-    app.kubernetes.io/component: rekor-search-ui
-    app.kubernetes.io/part-of: trusted-artifact-signer
+    app.podman.io/component: rekor-search-ui
+    app.podman.io/part-of: trusted-artifact-signer
     app.name: rekor-search-ui
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: rekor-search-ui
+      app.podman.io/component: rekor-search-ui
       app.name: rekor-search-ui
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: rekor-search-ui
-        app.kubernetes.io/part-of: trusted-artifact-signer
+        app.podman.io/component: rekor-search-ui
+        app.podman.io/part-of: trusted-artifact-signer
         app.name: rekor-search-ui
     spec:
       containers:

--- a/roles/tas_single_node/templates/manifests/rekor-search-ui/rekor-search-ui.j2
+++ b/roles/tas_single_node/templates/manifests/rekor-search-ui/rekor-search-ui.j2
@@ -4,30 +4,45 @@ metadata:
   name: "{{ tas_single_node_rekor_search_ui_pod }}"
   namespace: rekor-search-ui
   labels:
-    app.component: search
-    app.instance: scaffold
+    app.kubernetes.io/component: rekor-search-ui
+    app.kubernetes.io/part-of: trusted-artifact-signer
     app.name: rekor-search-ui
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.component: search
-      app.instance: scaffold
+      app.kubernetes.io/component: rekor-search-ui
       app.name: rekor-search-ui
   template:
     metadata:
       labels:
-        app.component: search
-        app.instance: scaffold
+        app.kubernetes.io/component: rekor-search-ui
+        app.kubernetes.io/part-of: trusted-artifact-signer
         app.name: rekor-search-ui
     spec:
       containers:
-        - name: rekor-ui
+        - name: rekor-search-ui
           image: "{{ tas_single_node_rekor_search_ui_image }}"
           imagePullPolicy: Always
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: file
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65533
+            allowPrivilegeEscalation: false
           env:
             - name: NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
               value: https://rekor.{{ tas_single_node_base_hostname }}
           ports:
             - containerPort: {{ tas_single_node_rekor_search_ui_port_tcp }}
               protocol: TCP
+      tolerations:
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300

--- a/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
@@ -4,9 +4,9 @@ metadata:
   name: "{{ tas_single_node_rekor_redis_pod }}"
   namespace: rekor-system
   labels:
-    app.component: redis
-    app.instance: scaffold
-    app.name: rekor
+    app.kubernetes.io/component: rekor-redis
+    app.kubernetes.io/part-of: trusted-artifact-signer
+    app.kubernetes.io/name: rekor-redis
 spec:
   replicas: 1
   selector:
@@ -16,18 +16,12 @@ spec:
     metadata:
       labels:
         app: rekor-redis
-        app.component: redis
-        app.instance: scaffold
+        app.kubernetes.io/component: rekor-redis
+        app.kubernetes.io/part-of: trusted-artifact-signer
         app.name: rekor
     spec:
       containers:
         - name: rekor-redis
-          args:
-            - /usr/bin/run-redis
-            - --bind
-            - 0.0.0.0
-            - --appendonly
-            - "yes"
           image: "{{ tas_single_node_rekor_redis_image }}"
 {% if tas_single_node_rekor_redis.redis.password != "" %}
           env:
@@ -41,11 +35,10 @@ spec:
           readinessProbe:
             exec:
               command:
-                - /usr/bin/run-redis
-                - --bind
-                - 0.0.0.0
-                - --appendonly
-                - "yes"
+                - /bin/sh
+                - '-c'
+                - '-i'
+                - test $(redis-cli -h 127.0.0.1 ping) = 'PONG'
             failureThreshold: 3
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -57,7 +50,13 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       enableServiceLinks: true
-      securityContext: {}
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        runAsUser: 65533
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
       serviceAccountName: rekor-redis
       tolerations:
         - effect: NoExecute

--- a/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
@@ -4,21 +4,21 @@ metadata:
   name: "{{ tas_single_node_rekor_redis_pod }}"
   namespace: rekor-system
   labels:
-    app.kubernetes.io/component: rekor-redis
-    app.kubernetes.io/part-of: trusted-artifact-signer
-    app.kubernetes.io/name: rekor-redis
+    app.podman.io/component: rekor-redis
+    app.podman.io/part-of: trusted-artifact-signer
+    app.name: rekor-redis
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: rekor-redis
+      app.name: rekor-redis
   template:
     metadata:
       labels:
         app: rekor-redis
-        app.kubernetes.io/component: rekor-redis
-        app.kubernetes.io/part-of: trusted-artifact-signer
-        app.name: rekor
+        app.podman.io/component: rekor-redis
+        app.podman.io/part-of: trusted-artifact-signer
+        app.name: rekor-redis
     spec:
       containers:
         - name: rekor-redis

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -4,23 +4,20 @@ metadata:
   name: "{{ tas_single_node_rekor_server_pod }}"
   namespace: rekor-system
   labels:
-    app.kubernetes.io/component: rekor-server
-    app.kubernetes.io/part-of: trusted-artifact-signer
-    app.name: rekor
-    pod-template-hash: 5c755b56f9
+    app.podman.io/component: rekor-server
+    app.podman.io/part-of: trusted-artifact-signer
+    app.name: rekor-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.name: rekor
-      pod-template-hash: 5c755b56f9
+      app.name: rekor-server
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: rekor-server
-        app.kubernetes.io/part-of: trusted-artifact-signer
-        app.name: rekor
-        pod-template-hash: 5c755b56f9
+        app.podman.io/component: rekor-server
+        app.podman.io/part-of: trusted-artifact-signer
+        app.name: rekor-redis
       annotations:
         prometheus.io/path: /metrics
         prometheus.io/port: "2112"

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -38,7 +38,7 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          livelinessProbe:
+          livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /ping

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -4,23 +4,21 @@ metadata:
   name: "{{ tas_single_node_rekor_server_pod }}"
   namespace: rekor-system
   labels:
-    app.component: server
-    app.instance: scaffold
+    app.kubernetes.io/component: rekor-server
+    app.kubernetes.io/part-of: trusted-artifact-signer
     app.name: rekor
     pod-template-hash: 5c755b56f9
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.component: server
-      app.instance: scaffold
       app.name: rekor
       pod-template-hash: 5c755b56f9
   template:
     metadata:
       labels:
-        app.component: server
-        app.instance: scaffold
+        app.kubernetes.io/component: rekor-server
+        app.kubernetes.io/part-of: trusted-artifact-signer
         app.name: rekor
         pod-template-hash: 5c755b56f9
       annotations:
@@ -30,6 +28,26 @@ spec:
     spec:
       containers:
         - name: rekor-server
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port : {{ tas_single_node_rekor_server_port_http }}
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          livelinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port : {{ tas_single_node_rekor_server_port_http }}
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           args:
             - serve
             - --trillian_log_server.address={{ tas_single_node_trillian_logserver_pod }}-pod
@@ -52,6 +70,12 @@ spec:
             - --port={{ tas_single_node_rekor_server_port_http }}
           image: "{{ tas_single_node_rekor_server_image }}"
           imagePullPolicy: IfNotPresent
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: file
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65533
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: {{ tas_single_node_rekor_server_port_http }}
               protocol: TCP

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.j2
@@ -4,19 +4,19 @@ metadata:
   name: "{{ tas_single_node_trillian_logserver_pod }}"
   namespace: trillian-system
   labels:
-    app.kubernetes.io/component: trillian-logserver
-    app.kubernetes.io/part-of: trusted-artifact-signer
+    app.podman.io/component: trillian-logserver
+    app.podman.io/part-of: trusted-artifact-signer
     app.name: trillian
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: trillian-logserver
+      app.podman.io/component: trillian-logserver
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: trillian-logserver
-        app.kubernetes.io/part-of: trusted-artifact-signer
+        app.podman.io/component: trillian-logserver
+        app.podman.io/part-of: trusted-artifact-signer
     spec:
 {% if tas_single_node_trillian_trusted_ca != "" %}
       volumes:

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.j2
@@ -4,20 +4,19 @@ metadata:
   name: "{{ tas_single_node_trillian_logserver_pod }}"
   namespace: trillian-system
   labels:
-    app.component: trillian-logserver
-    app.instance: scaffold
+    app.kubernetes.io/component: trillian-logserver
+    app.kubernetes.io/part-of: trusted-artifact-signer
     app.name: trillian
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.component: trillian-logserver
-      app.instance: scaffold
+      app.kubernetes.io/component: trillian-logserver
   template:
     metadata:
       labels:
-        app.component: trillian-logserver
-        app.instance: scaffold
+        app.kubernetes.io/component: trillian-logserver
+        app.kubernetes.io/part-of: trusted-artifact-signer
     spec:
 {% if tas_single_node_trillian_trusted_ca != "" %}
       volumes:

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.j2
@@ -4,8 +4,8 @@ metadata:
   name: "{{ tas_single_node_trillian_logsigner_pod }}"
   namespace: trillian-system
   labels:
-    app.component: trillian-logsigner
-    app.instance: scaffold
+    app.kubernetes.io/component: trillian-logsigner
+    app.kubernetes.io/part-of: trusted-artifact-signer
     app.name: trillian
 spec:
   replicas: 1
@@ -16,8 +16,8 @@ spec:
     metadata:
       labels:
         app: trillian-logsigner
-        app.component: trillian-logsigner
-        app.instance: scaffold
+        app.kubernetes.io/component: trillian-logsigner
+        app.kubernetes.io/part-of: trusted-artifact-signer
         app.name: trillian
     spec:
       initContainers:

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.j2
@@ -4,8 +4,8 @@ metadata:
   name: "{{ tas_single_node_trillian_logsigner_pod }}"
   namespace: trillian-system
   labels:
-    app.kubernetes.io/component: trillian-logsigner
-    app.kubernetes.io/part-of: trusted-artifact-signer
+    app.podman.io/component: trillian-logsigner
+    app.podman.io/part-of: trusted-artifact-signer
     app.name: trillian
 spec:
   replicas: 1
@@ -16,8 +16,8 @@ spec:
     metadata:
       labels:
         app: trillian-logsigner
-        app.kubernetes.io/component: trillian-logsigner
-        app.kubernetes.io/part-of: trusted-artifact-signer
+        app.podman.io/component: trillian-logsigner
+        app.podman.io/part-of: trusted-artifact-signer
         app.name: trillian
     spec:
       initContainers:

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-mysql.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-mysql.j2
@@ -4,8 +4,8 @@ metadata:
   name: "{{ tas_single_node_trillian_mysql_pod }}"
   namespace: trillian-system
   labels:
-    app.component: mysql
-    app.instance: scaffold
+    app.kubernetes.io/component: trillian-mysql
+    app.kubernetes.io/part-of: trusted-artifact-signer
     app.name: trillian
 spec:
   replicas: 1
@@ -16,12 +16,34 @@ spec:
     metadata:
       labels:
         app: trillian-mysql
-        app.component: mysql
-        app.instance: scaffold
+        app.kubernetes.io/component: trillian-mysql
+        app.kubernetes.io/part-of: trusted-artifact-signer
         app.name: trillian
     spec:
       containers:
         - name: trillian-mysql
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - '-c'
+                - 'mariadb -u {{ tas_single_node_trillian.mysql.user }} -p {{ tas_single_node_trillian.mysql.password }} -e "SELECT 1;"'
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - bash
+                - '-c'
+                - 'mariadb-admin -u {{ tas_single_node_trillian.mysql.user }} -p {{ tas_single_node_trillian.mysql.password }} ping'
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           image: "{{ tas_single_node_trillian_db_image }}"
           imagePullPolicy: IfNotPresent
           ports:

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-mysql.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-mysql.j2
@@ -4,8 +4,8 @@ metadata:
   name: "{{ tas_single_node_trillian_mysql_pod }}"
   namespace: trillian-system
   labels:
-    app.kubernetes.io/component: trillian-mysql
-    app.kubernetes.io/part-of: trusted-artifact-signer
+    app.podman.io/component: trillian-mysql
+    app.podman.io/part-of: trusted-artifact-signer
     app.name: trillian
 spec:
   replicas: 1
@@ -16,8 +16,8 @@ spec:
     metadata:
       labels:
         app: trillian-mysql
-        app.kubernetes.io/component: trillian-mysql
-        app.kubernetes.io/part-of: trusted-artifact-signer
+        app.podman.io/component: trillian-mysql
+        app.podman.io/part-of: trusted-artifact-signer
         app.name: trillian
     spec:
       containers:

--- a/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
+++ b/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
@@ -4,7 +4,7 @@ metadata:
   name: "{{ tas_single_node_tsa_server_pod }}"
   namespace: tsa-system
   labels:
-    app.instance: scaffold
+    app.kubernetes.io/part-of: trusted-artifact-signer
     app.name: tsa
     pod-template-hash: 74d5ff6f7f
 spec:
@@ -16,13 +16,33 @@ spec:
     metadata:
       labels:
         app: tsa-server
-        app.instance: scaffold
+        app.kubernetes.io/part-of: trusted-artifact-signer
         app.name: tsa
         pod-template-hash: 74d5ff6f7f
     spec:
       automountServiceAccountToken: true
       containers:
         - name: tsa-server
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: {{ tas_single_node_tsa_server_port_tcp }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: {{ tas_single_node_tsa_server_port_tcp }}
+              scheme: HTTP
+            initialDelayDeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           image: {{ tas_single_node_timestamp_authority_image }}
           imagePullPolicy: IfNotPresent
           command:

--- a/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
+++ b/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
@@ -4,9 +4,8 @@ metadata:
   name: "{{ tas_single_node_tsa_server_pod }}"
   namespace: tsa-system
   labels:
-    app.kubernetes.io/part-of: trusted-artifact-signer
-    app.name: tsa
-    pod-template-hash: 74d5ff6f7f
+    app.podman.io/part-of: trusted-artifact-signer
+    app.name: tsa-server
 spec:
   replicas: 1
   selector:
@@ -16,9 +15,8 @@ spec:
     metadata:
       labels:
         app: tsa-server
-        app.kubernetes.io/part-of: trusted-artifact-signer
-        app.name: tsa
-        pod-template-hash: 74d5ff6f7f
+        app.podman.io/part-of: trusted-artifact-signer
+        app.name: tsa-server
     spec:
       automountServiceAccountToken: true
       containers:

--- a/roles/tas_single_node/templates/manifests/tuf/tuf.j2
+++ b/roles/tas_single_node/templates/manifests/tuf/tuf.j2
@@ -4,8 +4,8 @@ metadata:
   name: "{{ tas_single_node_tuf_pod }}"
   namespace: tuf-system
   labels:
-    app.component: tuf
-    app.instance: scaffold
+    app.kubernetes.io/component: tuf
+    app.kubernetes.io/part-of: trusted-artifact-signer
     app.name: tuf
 spec:
   replicas: 1
@@ -16,8 +16,8 @@ spec:
     metadata:
       labels:
         app: tuf
-        app.component: tuf
-        app.instance: scaffold
+        app.kubernetes.io/component: tuf
+        app.kubernetes.io/part-of: trusted-artifact-signer
         app.name: tuf
     spec:
       containers:

--- a/roles/tas_single_node/templates/manifests/tuf/tuf.j2
+++ b/roles/tas_single_node/templates/manifests/tuf/tuf.j2
@@ -4,8 +4,8 @@ metadata:
   name: "{{ tas_single_node_tuf_pod }}"
   namespace: tuf-system
   labels:
-    app.kubernetes.io/component: tuf
-    app.kubernetes.io/part-of: trusted-artifact-signer
+    app.podman.io/component: tuf
+    app.podman.io/part-of: trusted-artifact-signer
     app.name: tuf
 spec:
   replicas: 1
@@ -16,8 +16,8 @@ spec:
     metadata:
       labels:
         app: tuf
-        app.kubernetes.io/component: tuf
-        app.kubernetes.io/part-of: trusted-artifact-signer
+        app.podman.io/component: tuf
+        app.podman.io/part-of: trusted-artifact-signer
         app.name: tuf
     spec:
       containers:


### PR DESCRIPTION
* Updating manifests with missing checks so it is exactly the same as the operator
* Didn't carry over the rekor-sharding volume as it's already it's own ticket
* Added new labels that semantically make sense, such as `part-of`, and decided on a general label scheme for our ansible deployment which is `podman.io`

Currently podman kube play only supports livenessProbes, but I also added readinessProbes if support is added in the future, plus doesn't harm the actual pod deployment in anyway