### PR TITLE
Configuring non root sudoer for molecule tests

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,9 +2,18 @@
 - name: Prepare
   hosts: molecule
   gather_facts: false
+  vars:
+    users:
+      - user: testingUser
+        password: testingPassword0x
   vars_files:
     - vars/vars.yml
 
   tasks:
+
     - name: Configure Dex OIDC instance
       ansible.builtin.include_tasks: ../dex-config.yaml
+
+    - name: Setup a non-root sudoer to replicate a user environment
+      ansible.builtin.include_tasks: ../testing_user_setup.yaml
+      with_items: "{{ users }}"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,7 +5,7 @@
   vars:
     users:
       - user: testingUser
-        password: testingPassword0x
+        password: password123
   vars_files:
     - vars/vars.yml
 

--- a/molecule/testing_user_setup.yaml
+++ b/molecule/testing_user_setup.yaml
@@ -1,13 +1,17 @@
 ---
+- name: Make sure Passlib is present
+  ansible.builtin.pip:
+    name: passlib
+    state: present
+  delegate_to: localhost
+
 - name: Create a non-root sudoer user
   ansible.builtin.user:
     name: "{{ item.user }}"
     shell: /bin/bash
     group: wheel
+    password: "{{ item.password | password_hash }}"
     create_home: yes
-
-- name: Set password for testingUser
-  ansible.builtin.shell: echo {{ item.password }} | passwd --stdin {{ item.user }}
 
 - name: Configure Sudoers for the user
   ansible.builtin.lineinfile:

--- a/molecule/testing_user_setup.yaml
+++ b/molecule/testing_user_setup.yaml
@@ -1,0 +1,51 @@
+---
+- name: Create a non-root sudoer user
+  ansible.builtin.user:
+    name: "{{ item.user }}"
+    shell: /bin/bash
+    group: wheel
+    create_home: yes
+
+- name: Set password for testingUser
+  ansible.builtin.shell: echo {{ item.password }} | passwd --stdin {{ item.user }}
+
+- name: Configure Sudoers for the user
+  ansible.builtin.lineinfile:
+    dest: /etc/sudoers
+    line: "{{ item.user }} ALL = (ALL) ALL"
+    validate: 'visudo -cf %s'
+
+- name: Create an .ssh directory
+  ansible.builtin.file:
+    path: "/home/{{ item.user }}/.ssh"
+    state: directory
+    mode: "0700"
+    owner: "{{ item.user }}"
+
+- name: Configure SSH access for new user
+  ansible.builtin.copy:
+    src: "{{ molecule_ephemeral_directory }}/id_rsa.pub"
+    dest: "/home/{{ item.user }}/.ssh/authorized_keys"
+    mode: "0600"
+    owner: "{{ item.user }}"
+
+- name: Edit SSH config to disallow root login
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^(#*)?PermitRootLogin'
+    line: "PermitRootLogin no"
+
+- name: Restart SSH
+  ansible.builtin.service:
+    name: sshd
+    state: restarted
+
+- name: Modify Molecule inventory
+  ansible.builtin.lineinfile:
+    path: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+    regexp: 'ansible_user:'
+    line: "ansible_user: {{ item.user }}, ansible_become_password: {{ item.password }}, ansible_become: true}"
+  delegate_to: localhost
+
+- name: Force refresh inventory
+  ansible.builtin.meta: refresh_inventory

--- a/molecule/user_provided/prepare.yml
+++ b/molecule/user_provided/prepare.yml
@@ -5,7 +5,7 @@
   vars:
     users:
       - user: testingUser
-        password: testingUser0x
+        password: password123
   vars_files:
     - vars/vars.yml
   tasks:

--- a/molecule/user_provided/prepare.yml
+++ b/molecule/user_provided/prepare.yml
@@ -2,10 +2,14 @@
 - name: Prepare
   hosts: molecule
   gather_facts: true
-  become: yes
+  vars:
+    users:
+      - user: testingUser
+        password: testingUser0x
   vars_files:
     - vars/vars.yml
   tasks:
+
     - name: Configure Dex OIDC instance
       ansible.builtin.include_tasks: ../dex-config.yaml
 
@@ -17,19 +21,27 @@
           - mariadb-server
         state: latest
 
+    - name: Set Redis password
+      shell: |
+        echo "CONFIG SET requirepass "password"" | redis-cli
+
+    - name: Allow external connections for Redis
+      ansible.builtin.lineinfile:
+        path: /etc/redis/redis.conf
+        regexp: 'bind 127.0.0.1 -::1'
+        line: "#bind 127.0.0.1 -::1"
+
     - name: Enable and start Redis
       ansible.builtin.service:
         name: redis
         enabled: yes
         state: started
 
-    - name: Set Redis password
-      shell: |
-        echo "CONFIG SET requirepass "password"" | redis-cli
-
-    - name: Allow external connections for Redis
-      shell: |
-        sed -i 's/#bind_address=0.0.0.0/bind_address=0.0.0.0/g' /etc/my.cnf.d/mariadb-server.cnf
+    - name: Allow external connections for MariaDB
+      ansible.builtin.lineinfile:
+        path: /etc/my.cnf.d/mariadb-server.cnf
+        regexp: '#bind_address=0.0.0.0'
+        line: "bind_address=0.0.0.0"
 
     - name: Enable and start MariaDB
       ansible.builtin.service:
@@ -63,3 +75,7 @@
         GRANT ALL ON trillian.* to 'mysql'@'%' IDENTIFIED BY 'password' WITH GRANT OPTION;
         FLUSH PRIVILEGES;
         EOF
+
+    - name: Set up a non-root sudoer to replicate a user environment
+      ansible.builtin.include_tasks: ../testing_user_setup.yaml
+      with_items: "{{ users }}" 


### PR DESCRIPTION
Adding Redis config which I forgot in initial scenario PR for user_provided
Adding non-root sudoer configuration for our scenario tests to emulate a real user environment
Changed shell commands to ansible collections, such as lineinfile

(Waiting for tf access so I can personally snoop around our molecule scenarios on a tf vm before merge)