### PR TITLE
Rename and fix up port variables

### DIFF
--- a/roles/tas_single_node/templates/manifests/ctlog/ctlog.j2
+++ b/roles/tas_single_node/templates/manifests/ctlog/ctlog.j2
@@ -47,11 +47,11 @@ spec:
           ports:
             - containerPort: {{ tas_single_node_ctlog_port_http }}
               protocol: TCP
-            - containerPort: {{ tas_single_node_ctlog_port_tcp }}
+            - containerPort: {{ tas_single_node_ctlog_port_metrics }}
               protocol: TCP
           args:
-            - --http_endpoint=0.0.0.0:{{ tas_single_node_ctlog_port_http}}
-            - --metrics_endpoint=0.0.0.0:{{ tas_single_node_ctlog_port_tcp}}
+            - --http_endpoint=0.0.0.0:{{ tas_single_node_ctlog_port_http }}
+            - --metrics_endpoint=0.0.0.0:{{ tas_single_node_ctlog_port_metrics }}
             - --log_config=/config/config
             - --alsologtostderr
           resources: {}

--- a/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.j2
+++ b/roles/tas_single_node/templates/manifests/fulcio/fulcio-server.j2
@@ -49,6 +49,7 @@ spec:
             - serve
             - --port={{ tas_single_node_fulcio_port_http }}
             - --grpc-port={{ tas_single_node_fulcio_port_grpc }}
+            - --metrics-port={{ tas_single_node_fulcio_port_metrics }}
             - --ca=fileca
             - --fileca-key
             - /var/run/fulcio-secrets/key.pem
@@ -67,7 +68,7 @@ spec:
               protocol: TCP
             - containerPort: {{ tas_single_node_fulcio_port_grpc }}
               protocol: TCP
-            - containerPort: {{ tas_single_node_fulcio_port_tcp }}
+            - containerPort: {{ tas_single_node_fulcio_port_metrics }}
               protocol: TCP
           resources: {}
           volumeMounts:

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -76,7 +76,7 @@ spec:
           ports:
             - containerPort: {{ tas_single_node_rekor_server_port_http }}
               protocol: TCP
-            - containerPort: {{ tas_single_node_rekor_server_port_tcp }}
+            - containerPort: {{ tas_single_node_rekor_server_port_metrics }}
               protocol: TCP
           resources: {}
           volumeMounts:

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.j2
@@ -38,7 +38,7 @@ spec:
             - --quota_system=mysql
             - --mysql_uri={{ tas_single_node_trillian.mysql.user }}:{{ tas_single_node_trillian.mysql.password }}@tcp({{ tas_single_node_trillian.mysql.host }}:{{ tas_single_node_trillian.mysql.port }})/{{ tas_single_node_trillian.mysql.database }}
             - --rpc_endpoint=0.0.0.0:{{ tas_single_node_trillian_logserver_port_rpc }}
-            - --http_endpoint=0.0.0.0:{{ tas_single_node_trillian_logserver_port_http }}
+            - --http_endpoint=0.0.0.0:{{ tas_single_node_trillian_logserver_port_metrics }}
             - --alsologtostderr
 {% if tas_single_node_trillian_trusted_ca != "" and not tas_single_node_trillian.database_deploy %}
             - --mysql_tls_ca=/var/run/configs/tas/ca-trust/trillian-trusted-ca.pem
@@ -71,7 +71,7 @@ spec:
           ports:
             - containerPort: {{ tas_single_node_trillian_logserver_port_rpc }}
               protocol: TCP
-            - containerPort: {{ tas_single_node_trillian_logserver_port_http }}
+            - containerPort: {{ tas_single_node_trillian_logserver_port_metrics }}
               protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.j2
@@ -44,14 +44,16 @@ spec:
           image: "{{ tas_single_node_trillian_log_signer_image }}"
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: {{ tas_single_node_trillian_logsigner_port_tcp }}
+            - containerPort: {{ tas_single_node_trillian_logsigner_port_metrics }}
+              protocol: TCP
+            - containerPort: {{ tas_single_node_trillian_logsigner_port_rpc }}
               protocol: TCP
           args:
             - --storage_system=mysql
             - --quota_system=mysql
             - --mysql_uri={{ tas_single_node_trillian.mysql.user }}:{{ tas_single_node_trillian.mysql.password }}@tcp({{ tas_single_node_trillian.mysql.host }}:{{ tas_single_node_trillian.mysql.port }})/{{ tas_single_node_trillian.mysql.database }}
-            - --rpc_endpoint=0.0.0.0:{{ tas_single_node_trillian_logserver_port_rpc }}
-            - --http_endpoint=0.0.0.0:{{ tas_single_node_trillian_logserver_port_http }}
+            - --rpc_endpoint=0.0.0.0:{{ tas_single_node_trillian_logsigner_port_rpc }}
+            - --http_endpoint=0.0.0.0:{{ tas_single_node_trillian_logsigner_port_metrics }}
             - --force_master=true
             - --alsologtostderr
 {% if tas_single_node_trillian_trusted_ca != "" and not tas_single_node_trillian.database_deploy %}

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -95,12 +95,12 @@ tas_single_node_cli_server_port_http: 8080
 
 tas_single_node_ctlog_pod: ctlog
 tas_single_node_ctlog_port_http: 6962
-tas_single_node_ctlog_port_tcp: 6963
+tas_single_node_ctlog_port_metrics: 6963
 
 tas_single_node_fulcio_pod: fulcio-server
 tas_single_node_fulcio_port_grpc: 5554
 tas_single_node_fulcio_port_http: 5555
-tas_single_node_fulcio_port_tcp: 2113
+tas_single_node_fulcio_port_metrics: 2113
 
 tas_single_node_nginx_pod: nginx
 tas_single_node_nginx_port_https: 8443
@@ -113,17 +113,19 @@ tas_single_node_rekor_redis_port_tcp: 6379
 
 tas_single_node_rekor_server_pod: rekor-server
 tas_single_node_rekor_server_port_http: 3001
-tas_single_node_rekor_server_port_tcp: 2112
+# note: this is hardcoded to 2112 in rekor and can't be changed right now
+tas_single_node_rekor_server_port_metrics: 2112
 
 tas_single_node_rekor_search_ui_pod: rekor-search-ui
 tas_single_node_rekor_search_ui_port_tcp: 3000
 
 tas_single_node_trillian_logserver_pod: trillian-logserver
 tas_single_node_trillian_logserver_port_rpc: 8091
-tas_single_node_trillian_logserver_port_http: 8090
+tas_single_node_trillian_logserver_port_metrics: 8090
 
 tas_single_node_trillian_logsigner_pod: trillian-logsigner
-tas_single_node_trillian_logsigner_port_tcp: 8191
+tas_single_node_trillian_logsigner_port_metrics: 8092
+tas_single_node_trillian_logsigner_port_rpc: 8093
 
 tas_single_node_trillian_mysql_pod: trillian-mysql
 tas_single_node_trillian_mysql_port_tcp: 3306


### PR DESCRIPTION
This PR renames some variables related to ports and fixes their usage. This still means that all container ports are exposed as host ports.

In a followup PR to this one, I will bump up the requirement to RHEL 9.4 (podman >= 4.9) which makes it possible to explicitly select ports to expose and will make sure the hostPort definitions are only done on the proper ports.