### PR TITLE
Tune Molecule settings to speed up CI runs

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,3 +15,12 @@ provisioner:
   name: ansible
   env:
     ANSIBLE_ROLES_PATH: "../../roles"
+  config_options:
+    defaults:
+      host_key_checking: false
+      internal_poll_interval: '0.0001'
+    ssh_connection:
+      ssh_args: '-o ControlMaster=auto -o ControlPersist=240s'
+      # note: if we ever need to do some more complex sudo/become usage, pipelining
+      # might need to be disabled, because it messes with these operations
+      pipelining: true

--- a/molecule/user_provided/molecule.yml
+++ b/molecule/user_provided/molecule.yml
@@ -15,3 +15,12 @@ provisioner:
   name: ansible
   env:
     ANSIBLE_ROLES_PATH: "../../roles"
+  config_options:
+    defaults:
+      host_key_checking: false
+      internal_poll_interval: '0.0001'
+    ssh_connection:
+      ssh_args: '-o ControlMaster=auto -o ControlPersist=240s'
+      # note: if we ever need to do some more complex sudo/become usage, pipelining
+      # might need to be disabled, because it messes with these operations
+      pipelining: true


### PR DESCRIPTION
This PR introduces bunch of options that significantly speed up Molecule CI runs; by my local testing, this will shave off more than five minutes of every molecule run (speeding up the first converge by ~3:30 and the idempotence converge by ~2:00).