### PR TITLE
Require RHEL >= 9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The ingress host names are as follows, where `<base_hostname>` is your deploymen
 
 * Ansible 2.16.0 or greater
 * Python 3.9.0 or greater
-* RHEL x86\_64 9.2 or greater.
+* RHEL x86\_64 9.4 or greater.
 * All client nodes using `cosign`, `gitsign`, and `ec` need the following:
   * Command-line access to the node with a user that has `sudo` privileges.
   * Updated DNS records or `/etc/hosts` entries with the ingress host names and IP addresses.

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ driver:
 platforms:
   - name: instance
     private_key_file_path: ~/.ssh/id_rsa
-    image_id: ami-0cd93da2da7f10cab
+    image_id: ami-0dac29b55bd7c33aa
     instance_type: m5.large
     aws_key_name: CI-TEST
 provisioner:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -12,6 +12,19 @@
 
   tasks:
 
+    - name: Install dnf versionlock plugin
+      ansible.builtin.package:
+        name: "python3-dnf-plugin-versionlock"
+        state: latest
+
+    # Ensure we test with the base RHEL 9.4 podman version.
+    # We're ok with doing this only in the default scenario - if we get later
+    # version in other scenarios, we actually get better test coverage for
+    # different podman versions.
+    - name: Lock podman to version 4.9
+      ansible.builtin.command:
+        cmd: "dnf versionlock add 'podman-4:4.9.4-16.el9_4.x86_64'"
+
     - name: Configure Dex OIDC instance
       ansible.builtin.include_tasks: ../dex-config.yaml
 

--- a/molecule/dex-config.yaml
+++ b/molecule/dex-config.yaml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: podman
     state: present
+    enable_plugin:
+      - versionlock
 
 - name: Create Dex config directory
   ansible.builtin.file:

--- a/molecule/user_provided/molecule.yml
+++ b/molecule/user_provided/molecule.yml
@@ -8,7 +8,7 @@ driver:
 platforms:
   - name: instance
     private_key_file_path: ~/.ssh/id_rsa
-    image_id: ami-0cd93da2da7f10cab
+    image_id: ami-0dac29b55bd7c33aa
     instance_type: m5.large
     aws_key_name: CI-TEST
 provisioner:

--- a/roles/tas_single_node/README.j2
+++ b/roles/tas_single_node/README.j2
@@ -4,7 +4,7 @@
 {%- if "version" in galaxy_collection %}
 Version: {{ galaxy_collection.version }}
 {% endif %}
-{{ argument_specs["main"].description }} Requires RHEL 9.2 or later.
+{{ argument_specs["main"].description }} Requires RHEL 9.4 or later.
 
 ## Role Arguments
 {% set path, options=entrypoint_options["main"][0] -%}

--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -3,7 +3,7 @@
 Version: 1.1.0
 
 Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_artifact_signer) service on a single managed node by using the `tas_single_node` role.
- Requires RHEL 9.2 or later.
+ Requires RHEL 9.4 or later.
 
 ## Role Arguments
 ### Required
@@ -30,7 +30,7 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 | tas_single_node_tsa_tink_key_resource | The KMS key for signing timestamp responses for Tink keysets. Valid options are: [gcp-kms://resource, aws-kms://resource, hcvault://]. | str |  |
 | tas_single_node_tsa_tink_keyset | The KMS-encrypted keyset for Tink that decrypts the tas_single_node_tsa_tink_key_resource string. | str |  |
 | tas_single_node_tsa_tink_hcvault_token | The authentication token for Hashicorp Vault API calls. | str |  |
-| tas_single_node_skip_os_install | Whether or not to skip the installation of the required operating system packages. Only use this option when all packages are already installed at the versions released for RHEL 9.2 or later. | bool |  `False`  |
+| tas_single_node_skip_os_install | Whether or not to skip the installation of the required operating system packages. Only use this option when all packages are already installed at the versions released for RHEL 9.4 or later. | bool |  `False`  |
 | tas_single_node_meta_issuers | The list of OIDC meta issuers allowed to authenticate Fulcio certificate requests. | list of dicts of 'tas_single_node_meta_issuers' options |  `[]`  |
 | tas_single_node_fulcio_trusted_oidc_ca | Trusted OpenID Connect (OIDC) CA certificate for Fulcio, used to validate the identity of the OIDC provider. | str |  |
 | tas_single_node_trillian_trusted_ca | Trusted CA certificate for Trillian, enabling secure TLS connections between the Trillian Logserver/Logsigner and the Trillian database. This CA certificate validates the authenticity of the Trillian database, ensuring encrypted and trusted data exchanges. | str |  |

--- a/roles/tas_single_node/meta/argument_specs.yml
+++ b/roles/tas_single_node/meta/argument_specs.yml
@@ -247,7 +247,7 @@ argument_specs:
       tas_single_node_skip_os_install:
         description: >
           Whether or not to skip the installation of the required operating system packages.
-          Only use this option when all packages are already installed at the versions released for RHEL 9.2 or later.
+          Only use this option when all packages are already installed at the versions released for RHEL 9.4 or later.
         type: "bool"
         required: false
         version_added: "1.1.0"

--- a/roles/tas_single_node/tasks/os.yml
+++ b/roles/tas_single_node/tasks/os.yml
@@ -7,6 +7,8 @@
   ansible.builtin.package: # noqa: package-latest
     name: "{{ tas_single_node_system_packages }}"
     state: latest
+    enable_plugin: # respect user's version locked packages, if any
+      - versionlock
 
 - name: Configure /etc/hosts DNS block
   ansible.builtin.blockinfile:

--- a/roles/tas_single_node/tasks/os.yml
+++ b/roles/tas_single_node/tasks/os.yml
@@ -2,7 +2,7 @@
 - name: Install System Packages dependencies
   # We use noqa here, because having all the packages upgrade to the latest version when
   # available is actually what we want. We need to prevent locking ourselves at old
-  # version with potential CVEs (at the same time we must upgrade to at least RHEL 9.2
+  # version with potential CVEs (at the same time we must upgrade to at least RHEL 9.4
   # package releases to ensure we can actually work).
   ansible.builtin.package: # noqa: package-latest
     name: "{{ tas_single_node_system_packages }}"

--- a/roles/tas_single_node/tasks/os_support.yml
+++ b/roles/tas_single_node/tasks/os_support.yml
@@ -3,14 +3,14 @@
     msg: "Unsupported OS. This role supports only RHEL and CentOS."
   when: ansible_facts['os_family'] != 'RedHat'
 
-- name: Fail if the OS version is lower than 9.2
+- name: Fail if the OS version is lower than 9.4
   ansible.builtin.fail:
-    msg: "Unsupported OS version. This role supports only RHEL 9.2 or higher or CentOS."
+    msg: "Unsupported OS version. This role supports only RHEL 9.4 or higher or CentOS."
   when: (ansible_facts['distribution'] in ['RedHat', 'CentOS'] and
     (ansible_facts['distribution_major_version'] | int < 9 or
     (ansible_facts['distribution_major_version'] | int == 9 and
     'distribution_minor_version' in ansible_facts and
-    ansible_facts['distribution_minor_version'] | int < 2)))
+    ansible_facts['distribution_minor_version'] | int < 4)))
 
 - name: Fail if the architecture is not x86_64
   ansible.builtin.fail:

--- a/roles/tas_single_node/templates/manifests/tuf/tuf.j2
+++ b/roles/tas_single_node/templates/manifests/tuf/tuf.j2
@@ -26,9 +26,6 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{ tas_single_node_tuf_port_http }}
-              # specify hostPort explicitly because of older podman versions that expose
-              # automatically, so we need to prevent clash with other container ports
-              hostPort: {{ tas_single_node_tuf_host_port_http }}
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -139,6 +139,5 @@ tas_single_node_tsa_server_port_tcp: 3002
 
 tas_single_node_tuf_pod: tuf
 tas_single_node_tuf_port_http: 8080
-tas_single_node_tuf_host_port_http: 8085
 
 tas_single_node_tuf_init_pod: tuf-init


### PR DESCRIPTION
This PR makes us require RHEL 9.4 as a minimum version.

Additionally, it removes the exposed hostPort of the TUF server which shouldn't be exposed otherwise than through nginx.