### PR TITLE
[SECURESIGN-1891] Fix configuration of attestation storage so Rekor can actually store attestations

### DIFF
--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -63,7 +63,9 @@ spec:
             - --enable_retrieve_api=true
             - --trillian_log_server.tlog_id={{ trillian_tree_id }}
             - --enable_attestation_storage
-            - --attestation_storage_bucket=file:///var/run/attestations
+            # NOTE: we need to use no_tmp_dir=true with file-based storage to prevent
+            # cross-device link error - see https://github.com/google/go-cloud/issues/3314
+            - "--attestation_storage_bucket=file:///var/run/attestations?no_tmp_dir=true"
             - --port={{ tas_single_node_rekor_server_port_http }}
           image: "{{ tas_single_node_rekor_server_image }}"
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This is to prevent errors when storing attestations such like this (which lead to the attestation not being stored at all):

```
2025-02-12T08:25:38.400Z	DEBUG api/entries.go:277	error storing attestation: blob (key "sha256:63e103a30619b9bb47acc8e28c476072f785329bdb7897bb93a642be48651719") (code=Unknown): rename /tmp/sha256:63e103a30619b9bb47acc8e28c476072f785329bdb7897bb93a642be48651719.182368764cd52996.tmp /var/run/attestations/sha256:63e103a30619b9bb47acc8e28c476072f785329bdb7897bb93a642be48651719: invalid cross-device link	{"operation": {"id": "rekor-server-7f846b7fdc-xtxfz/u5fdJYde07-000449"}}
```