### PR TITLE
Fixing health probe in Trillian-MySQL

### DIFF
--- a/roles/tas_single_node/templates/manifests/trillian/trillian-mysql.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-mysql.j2
@@ -27,7 +27,7 @@ spec:
               command:
                 - bash
                 - '-c'
-                - 'mariadb -u {{ tas_single_node_trillian.mysql.user }} -p {{ tas_single_node_trillian.mysql.password }} -e "SELECT 1;"'
+                - 'mariadb -u {{ tas_single_node_trillian.mysql.user }} -p{{ tas_single_node_trillian.mysql.password }} -e "SELECT 1;"'
             initialDelaySeconds: 10
             timeoutSeconds: 1
             periodSeconds: 10
@@ -38,7 +38,7 @@ spec:
               command:
                 - bash
                 - '-c'
-                - 'mariadb-admin -u {{ tas_single_node_trillian.mysql.user }} -p {{ tas_single_node_trillian.mysql.password }} ping'
+                - 'mariadb-admin -u {{ tas_single_node_trillian.mysql.user }} -p{{ tas_single_node_trillian.mysql.password }} ping'
             initialDelaySeconds: 10
             timeoutSeconds: 1
             periodSeconds: 10


### PR DESCRIPTION
During my testing of the restore procedure for ansible, I thought my terrible code was causing output errors just to find out after 2 hours that it was the health probes in the manifest.

Fix: Remove a space before the password :crying_cat_face: 