### PR TITLE
Prepare devel release 1.2.0-devel.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: redhat
 name: artifact_signer
-version: 1.1.0
+version: 1.2.0-devel.1
 
 readme: README.md
 authors:

--- a/molecule/default/vars/podman.yml
+++ b/molecule/default/vars/podman.yml
@@ -17,8 +17,8 @@ tas_single_node_podman:
       mirror: quay.io/securesign/trillian-redis
     - location: registry.redhat.io/rhtas/trillian-database-rhel9
       mirror: quay.io/securesign/trillian-database
-    - location: registry.redhat.io/rhtas/tuf-server-rhel9
-      mirror: quay.io/securesign/scaffold-tuf-server
+    - location: registry.redhat.io/rhtas/tuffer-rhel9
+      mirror: quay.io/securesign/tuffer
     - location: registry.redhat.io/rhtas/timestamp-authority-rhel9
       mirror: quay.io/securesign/timestamp-authority
     - location: registry.redhat.io/rhtas/rekor-search-ui-rhel9

--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -1,6 +1,6 @@
 <!--- to update this file, update files in the role's meta/ directory (and/or its README.j2 template) and run "make role-readme" -->
 # Ansible Role: redhat.artifact_signer.tas_single_node
-Version: 1.1.0
+Version: 1.2.0-devel.1
 
 Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_artifact_signer) service on a single managed node by using the `tas_single_node` role.
  Requires RHEL 9.4 or later.

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -97,23 +97,23 @@ tas_single_node_ct_logprefix: rhtasansible
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:4b5765bbfd3dac5fa027d2fb3d672b6ebffbc573b9413ab4cb189c50fa6f9a09"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:8d35d8a5488da5d1b563fd7eb2c05f1bcaf58f1c18a616087cec7a5c5dae80a0"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:7af78c7bc4df097ffeeef345f1d13289695f715221957579ee65daeef2fa3f5b"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:98ecea843babf275b6108d0d323adadb1f387129836d49a2c28385a3327e72fc"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:2d707d12e4f65e1a92b4de11465a5976d55e15ad6c9fefe994646ccd44c83840"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:21cd2c53a1d22cc7369b2260e41602d4eb090b86b2b411e9a87319350960a26c"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:81e10e34f02b21bb8295e7b5c93797fc8c0e43a1a0d8304cca1b07415a3ed6f5"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:ae1905bd9743389054526ae1d3069d78f02ca00dc7dd8f620e67177b0b892d1e"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:31e7318a9b19ed04ef0f25949f1f1709d293b532316b27a06f83fa5174547b17"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:61d76a754270016575de4a10078cb393a810b40c0e2edaa2cefe3ce4d070f016"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:18820b1fbdbc2cc3e917822974910332d937b03cfe781628bd986fd6a5ee318e"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:b7bd5b037f62f9b94575812ae129f1961d022b0e9c1931b01bdd3364d2dc89d1"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:6aa3ca40e0f9e32a0a211a930b21ff009b83e46609bfa5bb328979e4799d13c7"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:cd99ad5365f48dcf4c4b5ec02bd41ddb438fadb15ccaccb0df489d84e820a9b2"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:501612745e63e5504017079388bec191ffacf00ffdebde7be6ca5b8e4fd9d323"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:23bce7325c6bf65e30e1350a352bea9acfbc5f1ce933930ab1503c686ab2d285"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:79340be7918034c68a334a210ab872161827c99c2a1551a4fce8d5d27560a234"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:80c004f04a9d874a27df2d7e280f789572fae6186d42dbf3e532dfb194f58da2"
 tas_single_node_http_server_image:
   "registry.access.redhat.com/ubi9/httpd-24@sha256:7874b82335a80269dcf99e5983c2330876f5fe8bdc33dc6aa4374958a2ffaaee"
 tas_single_node_trillian_netcat_image:
@@ -121,15 +121,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:71fc4492c3a632663c1e17ec9364d87aa7bd459d3c723277b8b94a949b84c9fe"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:fce0a22c8872309554236bab3457715dda0a83eb40dc6a9ecd3477b8023369d0"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:60ca6f005a69b0ccb0be4bf6097e30eb4f2f9382e3761ea9600d7028449cafd0"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:3c93c15fc5c918a91b3da9f5bf2276e4d46d881b1031287e6ab28e6aeb23e019"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:e6a1c3cd0d8eff5bfafa079d1b04b9f084672ef693f4575f32a4a504c2caa60c"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/trillian-createtree-rhel9@sha256:f66a707e68fb0cdcfcddc318407fe60d72f50a7b605b5db55743eccc14a422ba"
+  "registry.redhat.io/rhtas/trillian-createtree-rhel9@sha256:71323012850d7b6c4ae5cc4c3ee32b86fba97794b5b4fee61ff7459c19a584dc"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:9537329d0166b8d41ffd5f5d79c052fc27abe426a20cba5733c84030013c4e29"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:b4eb9e6d7c29189c6abac6f03c1f131ee588014e635522ac28eca54d0b179d18"
 
 tas_single_node_podman: {}
 

--- a/roles/tas_single_node/meta/argument_specs.yml
+++ b/roles/tas_single_node/meta/argument_specs.yml
@@ -66,7 +66,7 @@ argument_specs:
         description: "Configuration options for the backfill redis job."
         type: "dict"
         required: false
-        version_added: "1.1.1"
+        version_added: "1.2.0"
         default:
           enabled: true
           schedule: "*-*-* 00:00:00"
@@ -75,12 +75,12 @@ argument_specs:
             description: "Enable or disable the backfill redis job."
             type: "bool"
             required: false
-            version_added: "1.1.1"
+            version_added: "1.2.0"
           schedule:
             description: "Schedule the backfill redis job should follow."
             type: "str"
             required: false
-            version_added: "1.1.1"
+            version_added: "1.2.0"
       tas_single_node_trillian:
         description: "Details on the database connection for Trillian. You can set this to a custom MySQL or MariaDB instance."
         type: "dict"
@@ -264,7 +264,7 @@ argument_specs:
           the user-provided private key for signing the root certificate, and the user-provided root certificate itself."
         type: "dict"
         required: false
-        version_added: "1.1.1"
+        version_added: "1.2.0"
         default:
           certificate:
             organization_name: ""
@@ -277,34 +277,34 @@ argument_specs:
             description: "Details on the certificate attributes for Fulcio."
             type: "dict"
             required: false
-            version_added: "1.1.1"
+            version_added: "1.2.0"
             options:
               organization_name:
                 description: "The name of the organization."
                 type: "str"
                 required: false
-                version_added: "1.1.1"
+                version_added: "1.2.0"
               organization_email:
                 description: "The email address of the organization."
                 type: "str"
                 required: false
-                version_added: "1.1.1"
+                version_added: "1.2.0"
               common_name:
                 description: "The common name (e.g., hostname) for the certificate."
                 type: "str"
                 required: false
-                version_added: "1.1.1"
+                version_added: "1.2.0"
           private_key:
             description: "The user-provided private key for Fulcio,
               used for signing root certificate (only RSA with > 2048 B pkey size or ECC with prime256v1 (==secp256r1) are supported)."
             type: "str"
             required: false
-            version_added: "1.1.1"
+            version_added: "1.2.0"
           root_ca:
             description: "The user-provided root certificate for Fulcio. This field is mutually exclusive with the certificate field."
             type: "str"
             required: false
-            version_added: "1.1.1"
+            version_added: "1.2.0"
 
       tas_single_node_rekor_public_key_retries:
         description: "The number of attempts to retrieve the Rekor public key when constructing the trust root."
@@ -510,7 +510,7 @@ argument_specs:
           Trusted OpenID Connect (OIDC) CA certificate for Fulcio, used to validate the identity of the OIDC provider.
         type: "str"
         required: false
-        version_added: "1.1.1"
+        version_added: "1.2.0"
         default: ""
       tas_single_node_trillian_trusted_ca:
         description: >
@@ -518,7 +518,7 @@ argument_specs:
           This CA certificate validates the authenticity of the Trillian database, ensuring encrypted and trusted data exchanges.
         type: "str"
         required: false
-        version_added: "1.1.1"
+        version_added: "1.2.0"
         default: ""
       tas_single_node_fulcio_server_image:
         description: "Fulcio image"
@@ -596,7 +596,7 @@ argument_specs:
         description: "Configuration options for Podman."
         type: "dict"
         required: false
-        version_added: "1.1.1"
+        version_added: "1.2.0"
         options:
           policy:
             description: >
@@ -604,7 +604,7 @@ argument_specs:
               Replaces the default policy, allowing you to enforce specific rules for image trust and verification in Podman.
             type: "str"
             required: false
-            version_added: "1.1.1"
+            version_added: "1.2.0"
           registry:
             description: >
               A list of registries and their corresponding mirrors. Each item in the list should specify
@@ -612,23 +612,23 @@ argument_specs:
             type: "list"
             elements: "dict"
             required: false
-            version_added: "1.1.1"
+            version_added: "1.2.0"
             options:
               location:
                 description: "The primary registry location for the image."
                 type: "str"
                 required: true
-                version_added: "1.1.1"
+                version_added: "1.2.0"
               mirror:
                 description: "The mirror registry to use for pulling images from the primary registry location."
                 type: "str"
                 required: true
-                version_added: "1.1.1"
+                version_added: "1.2.0"
       tas_single_node_cockpit:
         description: "Configuration options for Cockpit."
         type: "dict"
         required: false
-        version_added: "1.1.1"
+        version_added: "1.2.0"
         default:
           enabled: false
           user:
@@ -639,25 +639,25 @@ argument_specs:
             description: "Whether or not to install Cockpit."
             type: "bool"
             required: false
-            version_added: "1.1.1"
+            version_added: "1.2.0"
           user:
             description: "Configuration for the cockpit user."
             type: "dict"
             required: false
-            version_added: "1.1.1"
+            version_added: "1.2.0"
             options:
               create:
                 description: "Whether or not to create the cockpit user."
                 type: "bool"
                 required: false
-                version_added: "1.1.1"
+                version_added: "1.2.0"
               username:
                 description: "Username for the cockpit user."
                 type: "str"
                 required: false
-                version_added: "1.1.1"
+                version_added: "1.2.0"
               password:
                 description: "Password for the cockpit user."
                 type: "str"
                 required: true
-                version_added: "1.1.1"
+                version_added: "1.2.0"


### PR DESCRIPTION
Bumps the collection version, image checksums and moves the documented arguments from 1.1.1 (which we're not releasing) to 1.2.0.