### PR TITLE
Fixing missing volume mounts in rekor-redis and redis-backfill

### DIFF
--- a/roles/tas_single_node/templates/manifests/rekor/backfill_redis.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/backfill_redis.j2
@@ -73,3 +73,9 @@ spec:
                 -a "{{ tas_single_node_rekor_redis.redis.password }}" \
 {% endif %}
                 SET last_filled_index "$((endIndex + 1))"
+          volumeMounts:
+            - mountPath: /var/lib/redis/data
+              name: redis-backfill-storage
+      volumes:
+        - name: redis-backfill-storage
+          emptyDir: {}

--- a/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/redis-server.j2
@@ -23,6 +23,12 @@ spec:
       containers:
         - name: rekor-redis
           image: "{{ tas_single_node_rekor_redis_image }}"
+          volumeMounts:
+            - mountPath: /var/lib/redis/data
+              name: rekor-redis-storage
+      volumes:
+        - name: rekor-redis-storage
+          emptyDir: {}
 {% if tas_single_node_rekor_redis.redis.password != "" %}
           env:
             - name: REDIS_PASSWORD


### PR DESCRIPTION
Missing mounts forced redis to create anonymous ephemeral volumes. Fixed this by adding the required mounts.