### PR TITLE
[SECURESIGN-1469] Enable providing custom trust root content.

### DIFF
--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -44,6 +44,7 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 | tas_single_node_podman | Configuration options for Podman. | dict of 'tas_single_node_podman' options |  |
 | tas_single_node_cockpit | Configuration options for Cockpit. | dict of 'tas_single_node_cockpit' options |  `{'enabled': False, 'user': {'create': False, 'username': 'cockpit-user'}}`  |
 | tas_single_node_podman_volume_create_extra_args | Additional arguments to pass to the `podman volume create` command. This can be used to specify extra options when creating Podman volumes. | str |  |
+| tas_single_node_trust_root | Configuration options for the Trust Root. | dict of 'tas_single_node_trust_root' options |  `{'full_archive': ''}`  |
 
 #### Options for main > tas_single_node_rekor_redis
 
@@ -267,6 +268,12 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 | create | Whether or not to create the cockpit user. | bool | no |  |
 | username | Username for the cockpit user. | str | no |  |
 | password | Password for the cockpit user. | str | yes |  |
+
+#### Options for main > tas_single_node_trust_root
+
+|Option|Description|Type|Required|Default|
+|---|---|---|---|---|
+| full_archive | A compressed base64-encoded .tgz file of the trust root. This archive file has a single directory named `repository/`, containing the contents of the TUF repository, for example `1.root.json`. The default value is an empty string. Using the default value generates the trust root content, unless a trust root already exists. Specifying a `full_archive` string removes any earlier configured trust root content, and starts to use the new specified content. If changing this value back to an empty string after setting the `full_archive` option, then we continue serving the previous value for the trust root content. To reset the trust root content, you must remove all files in the volume associated with the `tuf-repository` pod. | str | no |  |
 
 ## Example Playbook
 

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -102,6 +102,9 @@ tas_single_node_oidc_issuers: []
 
 tas_single_node_meta_issuers: []
 
+tas_single_node_trust_root:
+  full_archive: ""
+
 tas_single_node_ctlog_ca_passphrase: rhtas
 
 

--- a/roles/tas_single_node/meta/argument_specs.yml
+++ b/roles/tas_single_node/meta/argument_specs.yml
@@ -768,3 +768,24 @@ argument_specs:
         required: false
         version_added: "1.2.0"
         default: ""
+      tas_single_node_trust_root:
+        description: "Configuration options for the Trust Root."
+        type: "dict"
+        required: false
+        version_added: "1.2.0"
+        default:
+          full_archive: ""
+        options:
+          full_archive:
+            description: >
+              A compressed base64-encoded .tgz file of the trust root. This archive file has a single directory
+              named `repository/`, containing the contents of the TUF repository, for example `1.root.json`.
+              The default value is an empty string. Using the default value generates the trust root content,
+              unless a trust root already exists. Specifying a `full_archive` string removes any earlier configured
+              trust root content, and starts to use the new specified content. If changing this value back
+              to an empty string after setting the `full_archive` option, then we continue serving the previous
+              value for the trust root content. To reset the trust root content, you must remove all files
+              in the volume associated with the `tuf-repository` pod.
+            type: str
+            required: false
+            version_added: "1.2.0"

--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -39,13 +39,89 @@
       data:
         ctfe-pubkey: |
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ctlog_public_key.0) | list | first).content }}
-        fulcio-cert: |
+        fulcio_v1.crt.pem: |
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}
         rekor-pubkey: |
           {{ rekor_public_key_result.stdout | b64encode }}
-        tsa-cert: |
+        tsa.certchain.pem: |
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_tsa_certificate_chain) | list | first).content }}
+        # If user switches back from providing to not providing the full_archive, we have to trigger
+        # the rerun of the init job somehow; we do this by triggering a change in this secret.
+        __change_detection: "{% if 'full_archive' in tas_single_node_trust_root %}{{ 1 | b64encode }}{% else %}{{ 0 | b64encode }}{% endif %}"
   register: secret_result
+
+- name: Create the TUF repository volume
+  ansible.builtin.command:
+    cmd: "podman volume create --ignore {{ tas_single_node_tuf_repository_volume_name }}"
+  changed_when: false
+
+- name: Set TUF repository content to the provided trusted root archive
+  when: '"full_archive" in tas_single_node_trust_root and tas_single_node_trust_root.full_archive != ""'
+  block:
+    - name: Mount the TUF repository volume
+      ansible.builtin.command:
+        cmd: "podman volume mount {{ tas_single_node_tuf_repository_volume_name }}"
+      register: volume_mount_result
+      changed_when: false
+
+    - name: Create the directory to extract provided archive to
+      ansible.builtin.file:
+        state: directory
+        dest: "{{ tas_single_node_tuf_repo_dir }}"
+        mode: "0700"
+
+    - name: Create the archive file
+      ansible.builtin.file:
+        state: touch
+        access_time: preserve
+        modification_time: preserve
+        dest: "{{ tas_single_node_tuf_repo_dir }}/repository.tar.gz"
+        mode: "0600"
+
+    # Believe it or not, this is the only way to write binary data to file with Ansible
+    - name: Write the archive to a file
+      ansible.builtin.shell:
+        cmd: "set -o pipefail && echo '{{ tas_single_node_trust_root.full_archive }}' | base64 -d > '{{ tas_single_node_tuf_repo_dir }}/repository.tar.gz'"
+      changed_when: false
+
+    - name: Extract the archive
+      ansible.builtin.unarchive:
+        remote_src: true
+        src: "{{ tas_single_node_tuf_repo_dir }}/repository.tar.gz"
+        dest: "{{ tas_single_node_tuf_repo_dir }}"
+        mode: "0744"
+        list_files: true
+      register: unarchive_result
+
+    - name: Validate archive contents
+      ansible.builtin.fail:
+        msg: "Incorrect TUF repository provided, missing '{{ item }}' in the archive"
+      loop:
+        - "tuf-repo/root.json"
+        - "tuf-repo/1.root.json"
+        - "tuf-repo/1.snapshot.json"
+        - "tuf-repo/1.targets.json"
+        - "tuf-repo/timestamp.json"
+      when: item not in unarchive_result.files
+
+    - name: Synchronize contents of the provided archive to the volume
+      ansible.posix.synchronize:
+        src: "{{ tas_single_node_tuf_repo_dir }}/tuf-repo/"
+        dest: "{{ volume_mount_result.stdout }}"
+        delete: true
+        group: false
+        owner: false
+        recursive: true
+        times: true
+        rsync_opts:
+          - "--chmod=F0644"
+          - "--chmod=D0755"
+      delegate_to: "{{ inventory_hostname }}"
+
+    - name: Unmount the TUF repository volume
+      ansible.builtin.command:
+        cmd: "podman volume unmount {{ tas_single_node_tuf_repository_volume_name }}"
+      changed_when: false
 
 - name: Initialize trust root
   ansible.builtin.include_tasks: podman/install_manifest.yml
@@ -58,6 +134,7 @@
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/tuf/tuf-init.j2') | from_yaml }}"
       secret: "{{ tas_single_node_tuf_secret_config }}"
       secret_changed: "{{ secret_result.changed }}"
+  when: '"full_archive" not in tas_single_node_trust_root or tas_single_node_trust_root.full_archive == ""'
 
 - name: Deploy TUF server pod
   ansible.builtin.include_tasks: podman/install_manifest.yml

--- a/roles/tas_single_node/templates/manifests/tuf/tuf-init.j2
+++ b/roles/tas_single_node/templates/manifests/tuf/tuf-init.j2
@@ -40,10 +40,10 @@ spec:
               --ctlog-key /var/run/tuf-secrets/ctfe-pubkey
 {% endif %}
 {% if tas_single_node_fulcio_enabled %}
-              --fulcio-cert /var/run/tuf-secrets/fulcio-cert
+              --fulcio-cert /var/run/tuf-secrets/fulcio_v1.crt.pem
 {% endif %}
 {% if tas_single_node_tsa_enabled %}
-              --tsa-cert /var/run/tuf-secrets/tsa-cert
+              --tsa-cert /var/run/tuf-secrets/tsa.certchain.pem
 {% endif %}
               /var/run/target
           image: "{{ tas_single_node_tuf_image }}"

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -23,10 +23,12 @@ tas_single_node_client_server_enabled: true
 tas_single_node_createtree_enabled: true
 
 # Directory Structure
+# NOTE: Do not change these values, they're referred to from docs
 tas_single_node_config_dir: /etc/rhtas
 tas_single_node_certs_dir: "{{ tas_single_node_config_dir }}/certs"
 tas_single_node_kube_manifest_dir: "{{ tas_single_node_config_dir }}/manifests"
 tas_single_node_kube_configmap_dir: "{{ tas_single_node_config_dir }}/configs"
+tas_single_node_tuf_repo_dir: "{{ tas_single_node_config_dir }}/tuf-repo"
 
 # Infrastructure Certs
 tas_single_node_remote_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_private_key_filename }}"
@@ -35,10 +37,11 @@ tas_single_node_remote_fulcio_private_key: "{{ tas_single_node_certs_dir }}/{{ t
 tas_single_node_remote_fulcio_auto_generated_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_fulcio_auto_generated_private_key_filename }}"
 tas_single_node_remote_fulcio_user_provided_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_fulcio_user_provided_private_key_filename }}"
 tas_single_node_remote_fulcio_public_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_fulcio_public_key_filename }}"
-tas_single_node_remote_fulcio_root_ca: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_fulcio_root_ca_filename }}"
 tas_single_node_remote_ctlog_private_key: ["{{ tas_single_node_certs_dir }}/{{ tas_single_node_ctlog_private_key_filename }}"]
-tas_single_node_remote_ctlog_public_key: ["{{ tas_single_node_certs_dir }}/{{ tas_single_node_ctlog_public_key_filename }}"]
 tas_single_node_remote_rekor_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_rekor_signer_filename }}"
+# NOTE: Do not change these values, they're referred to from docs
+tas_single_node_remote_fulcio_root_ca: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_fulcio_root_ca_filename }}"
+tas_single_node_remote_ctlog_public_key: ["{{ tas_single_node_certs_dir }}/{{ tas_single_node_ctlog_public_key_filename }}"]
 tas_single_node_remote_rekor_public_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_rekor_public_key_filename }}"
 
 # Functional Keys
@@ -48,16 +51,17 @@ tas_single_node_fulcio_private_key_filename: fulcio.key
 tas_single_node_fulcio_auto_generated_private_key_filename: auto_generated_fulcio.key
 tas_single_node_fulcio_user_provided_private_key_filename: user_provided_fulcio.key
 tas_single_node_fulcio_public_key_filename: fulcio.pub
-tas_single_node_fulcio_root_ca_filename: fulcio.pem
 tas_single_node_ctlog_private_key_filename: ctlog0.key
-tas_single_node_ctlog_public_key_filename: ctlog0.pub
 tas_single_node_rekor_signer_filename: rekor-signer.key
-tas_single_node_rekor_public_key_filename: rekor-pub-key.pub
 tas_single_node_tsa_private_key_filename: tsa.key
 tas_single_node_tsa_leaf_certificate_filename: tsa-leaf-certificate.pem
 tas_single_node_tsa_signer_private_key_filename: tsa-signer-private-key.pem
-tas_single_node_tsa_cert_chain_filename: tsa-cert-chain.pem
 tas_single_node_tsa_ntp_config_filename: ntpsync.yaml
+# NOTE: Do not change these values, they're referred to from docs
+tas_single_node_tsa_cert_chain_filename: tsa-cert-chain.pem
+tas_single_node_fulcio_root_ca_filename: fulcio.pem
+tas_single_node_ctlog_public_key_filename: ctlog0.pub
+tas_single_node_rekor_public_key_filename: rekor-pub-key.pub
 
 # Secrets,Certs and Configuration locations
 tas_single_node_fulcio_server_config: "{{ tas_single_node_kube_configmap_dir }}/fulcio-config.yaml"
@@ -85,9 +89,10 @@ tas_single_node_tuf_signing_keys_volume_name: "tuf-signing-keys"
 # Timestamp Authority Config
 tas_single_node_tsa_signer_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_signer_private_key_filename }}"
 tas_single_node_remote_tsa_leaf_certificate: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_leaf_certificate_filename }}"
-tas_single_node_tsa_certificate_chain: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_cert_chain_filename }}"
 tas_single_node_remote_tsa_private_key: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_private_key_filename }}"
 tas_single_node_tsa_ntp_config_file: "{{ tas_single_node_config_dir }}/{{ tas_single_node_tsa_ntp_config_filename }}"
+# NOTE: Do not change this value, it's referred to from docs
+tas_single_node_tsa_certificate_chain: "{{ tas_single_node_certs_dir }}/{{ tas_single_node_tsa_cert_chain_filename }}"
 
 # Secrets,Certs and Configuration names
 tas_single_node_trillian_trusted_ca_configmap_name: "trillian-trusted-ca"


### PR DESCRIPTION
This PR will allow users to provide archive with custom content of the Trust Root as a configuration variable that contains base64-encoded tar.gz file.

Note: I will extend the user-provided Molecule scenario for this usecase in another PR once we can override all of Fulcio, CTLog, TSA and Rekor targets (currently custom keys for Rekor and CTLog are impossible to configure).