### PR TITLE
Adding `trusted_ca` config option to TSA

### DIFF
--- a/molecule/user_provided/vars/vars.yml
+++ b/molecule/user_provided/vars/vars.yml
@@ -29,3 +29,4 @@ tas_single_node_tsa:
   ntp_config: "{{ lookup('file', molecule_scenario_directory + '/test_creds/ntpsync.yaml') }}"
   signer_private_key: "{{ lookup('file', molecule_scenario_directory + '/test_creds/private-key.pem') }}"
   certificate_chain: "{{ lookup('file', molecule_scenario_directory + '/test_creds/cert-chain.pem') }}"
+  trusted_ca: ""

--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -26,7 +26,7 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 | tas_single_node_rekor_public_key_retries | The number of attempts to retrieve the Rekor public key when constructing the trust root. | int |  `5`  |
 | tas_single_node_rekor_public_key_delay | The number of seconds to wait before retrying the retrieval of the Rekor public key when constructing the trust root. | int |  `10`  |
 | tas_single_node_setup_host_dns | Set up DNS on the managed host to resolve URLs of the configured RHTAS services. | bool |  `True`  |
-| tas_single_node_tsa | Details on the certificate and configuration options for Timestamp Authority. Includes organizational details, the different signer types such as `file`, `kms`, and `tink`, NTP monitoring configuration and user provided certificate chain + signer private key. | dict of 'tas_single_node_tsa' options |  `{'signer_type': 'file', 'certificate': {'organization_name': '', 'organization_email': '', 'common_name': ''}, 'kms': {'key_resource': ''}, 'tink': {'key_resource': '', 'keyset': '', 'hcvault_token': ''}, 'signer_private_key': '', 'certificate_chain': '', 'signer_passphrase': 'rhtas', 'ca_passphrase': 'rhtas', 'ntp_config': ''}`  |
+| tas_single_node_tsa | Details on the certificate and configuration options for Timestamp Authority. Includes organizational details, the different signer types such as `file`, `kms`, and `tink`, NTP monitoring configuration and user provided certificate chain + signer private key. | dict of 'tas_single_node_tsa' options |  `{'signer_type': 'file', 'certificate': {'organization_name': '', 'organization_email': '', 'common_name': ''}, 'kms': {'key_resource': ''}, 'tink': {'key_resource': '', 'keyset': '', 'hcvault_token': ''}, 'signer_private_key': '', 'certificate_chain': '', 'signer_passphrase': 'rhtas', 'ca_passphrase': 'rhtas', 'ntp_config': '', 'trusted_ca': ''}`  |
 | tas_single_node_skip_os_install | Whether or not to skip the installation of the required operating system packages. Only use this option when all packages are already installed at the versions released for RHEL 9.4 or later. | bool |  `False`  |
 | tas_single_node_meta_issuers | The list of OIDC meta issuers allowed to authenticate Fulcio certificate requests. | list of dicts of 'tas_single_node_meta_issuers' options |  `[]`  |
 | tas_single_node_fulcio_trusted_oidc_ca | Trusted OpenID Connect (OIDC) CA certificate for Fulcio, used to validate the identity of the OIDC provider. | str |  |
@@ -168,6 +168,7 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 | signer_passphrase | Passphrase used to access signer private key. | str | no |  |
 | ca_passphrase | Passphrase used to access certificate authority. | str | no |  |
 | ntp_config | NTP config for time syncing within a unified consensus of vendors such as Google, Amazon, and more. Valid file format and configuration can be found [here](https://github.com/sigstore/timestamp-authority/blob/main/pkg/ntpmonitor/ntpsync.yaml). | str | no |  |
+| trusted_ca | Trusted CA certificate for Trusted Timestamp Authority, enabling secure TLS connections. Used to ensure authenticity and trusted data exchange. | str | no |  |
 
 #### Options for main > tas_single_node_tsa > certificate
 

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -77,6 +77,7 @@ tas_single_node_tsa:
   signer_passphrase: rhtas
   ca_passphrase: rhtas
   ntp_config: ""
+  trusted_ca: ""
 
 tas_single_node_skip_os_install: false
 

--- a/roles/tas_single_node/meta/argument_specs.yml
+++ b/roles/tas_single_node/meta/argument_specs.yml
@@ -356,6 +356,7 @@ argument_specs:
           signer_passphrase: rhtas
           ca_passphrase: rhtas
           ntp_config: ""
+          trusted_ca: ""
         options:
           signer_type:
             description: "The signer type for TSA. Options include `file`, `kms`, `tink`."
@@ -443,6 +444,13 @@ argument_specs:
             description: >
               NTP config for time syncing within a unified consensus of vendors such as Google, Amazon, and more.
               Valid file format and configuration can be found [here](https://github.com/sigstore/timestamp-authority/blob/main/pkg/ntpmonitor/ntpsync.yaml).
+            type: "str"
+            required: false
+            version_added: "1.2.0"
+          trusted_ca:
+            description: >
+              Trusted CA certificate for Trusted Timestamp Authority, enabling secure TLS connections.
+              Used to ensure authenticity and trusted data exchange.
             type: "str"
             required: false
             version_added: "1.2.0"

--- a/roles/tas_single_node/tasks/podman/tsa.yml
+++ b/roles/tas_single_node/tasks/podman/tsa.yml
@@ -62,6 +62,9 @@
       data:
         ntpsync.yaml: |
           {{ tas_single_node_tsa.ntp_config }}
+
+        tsa-trusted-ca.pem: |
+          {{ tas_single_node_tsa.trusted_ca }}
   register: configmap_result
 
 - name: Deploy TSA Pod

--- a/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
+++ b/roles/tas_single_node/templates/manifests/tsa/tsa-server.j2
@@ -43,6 +43,11 @@ spec:
             failureThreshold: 3
           image: {{ tas_single_node_timestamp_authority_image }}
           imagePullPolicy: IfNotPresent
+{% if tas_single_node_tsa.trusted_ca != '' %}
+          env:
+            - name: SSL_CERT_DIR
+              value: "/var/run/configs/tas/ca-trust"
+{% endif %}
           command:
             - "timestamp-server"
           args:
@@ -71,6 +76,11 @@ spec:
               protocol: TCP
           resources: {}
           volumeMounts:
+{% if tas_single_node_tsa.trusted_ca != '' %}
+            - name: ca-trust
+              mountPath: /var/run/configs/tas/ca-trust/tsa-trusted-ca.pem
+              subPath: tsa-trusted-ca.pem
+{% endif %}
 {% if tas_single_node_tsa.ntp_config != '' %}
             - name: tsa-ntp-config
               mountPath: /etc/config/ntpsync.yaml
@@ -106,6 +116,14 @@ spec:
           operator: Exists
           tolerationSeconds: 300
       volumes:
+{% if tas_single_node_tsa.trusted_ca != '' %}
+        - name: ca-trust
+          configMap:
+            name: tsa-config
+            items:
+              - key: tsa-trusted-ca.pem
+                path: tsa-trusted-ca.pem
+{% endif %}
 {% if tas_single_node_tsa.ntp_config != '' %}
         - name: tsa-ntp-config
           configMap:


### PR DESCRIPTION
Replicating Trillian and Fulcio - Adding trusted-ca to custom trust store using SSL_CERT_DIR var.