### PR TITLE
:robot: [RHTAS-build-bot] [main] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -109,23 +109,23 @@ tas_single_node_ctlog_ca_passphrase: rhtas
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:f58588d336b578da548831d555d627614eabf993a693f570047c2a2bafff5b1b"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:ec4fcbce2f1acf8eb3ae7daa133dd7deac09607fea1102b422cee6d9f81e7648"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:89eec6d832ff3cd032ace453f950c88b075994e5b905d5347fd927202876c512"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:c6a365be4650af080cbfb7a3fb0eea5e7365498699560dc6ff977e9efadfdbc3"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:0a9713466a55b5c79eae8dce71fd33184fdd07e59ffd530ca17b60895374902c"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:4dad4ac1bcf6e4f2261521e81a8cec4323ff18953ac65e303ddff9303f1b494a"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:993394a07f178f89eb103b33fbf7bc007db3cca98eaa79e01b6e6a1ba2a302e6"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:936c7be0991f92185c6bfeddddde05c5c96273af30d870ad7e14a50886b0ddae"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:5e85b4eb162c1d136add09491af72413a5d7475df041ce4340b919302bee6600"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:47948b7852bcca09015e5fd264c7c30d5c79bce0e365cd69438ef0b9a1d52a9f"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:0b708607468e175139de6838b90b7fa2fb22985e2f0e8caa81e0f97b0a1a590c"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:afe742d08bbeea7716a0fdc16b9bd43b3e00c4bed09b169b2bc3bcdf9518c27a"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:59b06a2fc7290b0dd7738f09c0d3fe19eab69f2bea10c998c481da3139c25c78"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:631cebd3f08ccaba66a7a16f20f87af6c921810d1671a69e39c26dfd6f63d6f4"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:614ba2e79a5f5230bea925d001756c66ac09deac24aa529628095540d8219180"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:2694ab5a3927d344fc175b77ef3a308261938a17fdcaa4466d0e519f21575813"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:c327853589a048b0848773bc19e74edc598498eda2021914e92b4fcfd1059a02"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:187a01b51cbdebbbdf2a1a29374450e506dd09b61d49fc05da6f7ec61f3615c4"
 tas_single_node_http_server_image:
   "registry.access.redhat.com/ubi9/httpd-24@sha256:7874b82335a80269dcf99e5983c2330876f5fe8bdc33dc6aa4374958a2ffaaee"
 tas_single_node_trillian_netcat_image:
@@ -135,13 +135,13 @@ tas_single_node_nginx_image:
 tas_single_node_timestamp_authority_image:
   "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:0fdd5e119325e8c30f5ef0da9b0a78469143a3d222e8b92d0d972acbed8db99c"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:1432b47ddd881eb1909453e939c791825e7853b4abc00a12dddd948f99022ab3"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:eaa4c0e539930fc5f007752a5b19d82cf4de7ad11502124ee185d5c3990c3628"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/trillian-createtree-rhel9@sha256:43da71295323660fd9992e3ba2e2ad63ed9f729dbb42401e041ad02c73da718a"
+  "registry.redhat.io/rhtas/trillian-createtree-rhel9@sha256:376c8299f11b747047c76d73fb5989219205ea9ee630459c1089ccba3f52db5f"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:ce30450e9e3aee7368bd9ba7f756d7af0f7c0e052cd57951256adaa9c78fb562"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:58ed61e60fb8447fa9c9af4996efe612ed3220f291c9e190cfbb785df0585410"
 
 tas_single_node_podman: {}
 


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `1432b47` | `eaa4c0e` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `f58588d` | `ec4fcbc` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `5e85b4e` | `47948b7` |
| registry.redhat.io/rhtas/trillian-createtree-rhel9 | `43da712` | `376c829` |
| registry.redhat.io/rhtas/client-server-rhel9 | `ce30450` | `58ed61e` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `993394a` | `936c7be` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `89eec6d` | `c6a365b` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `614ba2e` | `2694ab5` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `59b06a2` | `631cebd` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `0a97134` | `4dad4ac` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `c327853` | `187a01b` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `0b70860` | `afe742d` |
---