### PR TITLE
[SECURESIGN-1984] Fix handling of default values in nested variables

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -26,57 +26,11 @@ tas_single_node_trillian:
     host: trillian-mysql-pod
     port: 3306
 
-tas_single_node_ingress_certificates:
-  fulcio:
-    certificate: ""
-    private_key: ""
-  rekor:
-    certificate: ""
-    private_key: ""
-  tuf:
-    certificate: ""
-    private_key: ""
-  tsa:
-    certificate: ""
-    private_key: ""
-  rekor-search:
-    certificate: ""
-    private_key: ""
-  cli-server:
-    certificate: ""
-    private_key: ""
-
-tas_single_node_fulcio:
-  certificate:
-    organization_name: ""
-    organization_email: ""
-    common_name: ""
-  private_key: ""
-  root_ca: ""
-
 tas_single_node_rekor_public_key_retries: 5
 tas_single_node_rekor_public_key_delay: 10
 
 tas_single_node_setup_host_dns: true
 tas_single_node_base_hostname: ""
-
-tas_single_node_tsa:
-  signer_type: file
-  certificate:
-    organization_name: ""
-    organization_email: ""
-    common_name: ""
-  kms:
-    key_resource: ""
-  tink:
-    key_resource: ""
-    keyset: ""
-    hcvault_token: ""
-  signer_private_key: ""
-  certificate_chain: ""
-  signer_passphrase: rhtas
-  ca_passphrase: rhtas
-  ntp_config: ""
 
 tas_single_node_skip_os_install: false
 

--- a/roles/tas_single_node/tasks/main.yml
+++ b/roles/tas_single_node/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- import_tasks: set_defaults.yml
+- name: Importing default values
+  ansible.builtin.import_tasks: set_defaults.yml
 
 - name: Check configuration correctness
   ansible.builtin.include_tasks: configuration_check.yml

--- a/roles/tas_single_node/tasks/main.yml
+++ b/roles/tas_single_node/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- import_tasks: set_defaults.yml
+
 - name: Check configuration correctness
   ansible.builtin.include_tasks: configuration_check.yml
 

--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -26,7 +26,7 @@
     cmd: "podman kube play {{ podman_spec.secret }}"
   when: podman_spec.secret is defined
   changed_when: podman_spec.secret is defined and podman_spec.secret_changed
-  no_log : true
+  no_log: true
 
 - name: Copy Systemd file to Server
   ansible.builtin.template:

--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -26,6 +26,7 @@
     cmd: "podman kube play {{ podman_spec.secret }}"
   when: podman_spec.secret is defined
   changed_when: podman_spec.secret is defined and podman_spec.secret_changed
+  no_log : true
 
 - name: Copy Systemd file to Server
   ansible.builtin.template:

--- a/roles/tas_single_node/tasks/set_defaults.yml
+++ b/roles/tas_single_node/tasks/set_defaults.yml
@@ -1,0 +1,8 @@
+---
+- name: Set default values for _tas_single_node variables
+  ansible.builtin.set_fact:
+    tas_single_node_tsa: "{{ _tas_single_node_tsa | combine(tas_single_node_tsa | default({}, true), recursive=true) }}"
+    tas_single_node_fulcio: "{{ _tas_single_node_fulcio | combine(tas_single_node_fulcio | default({}, true), recursive=true) }}"
+    tas_single_node_ingress_certificates: "{{ _tas_single_node_ingress_certificates | combine(tas_single_node_ingress_certificates | default({}, true), recursive=true) }}"
+
+

--- a/roles/tas_single_node/tasks/set_defaults.yml
+++ b/roles/tas_single_node/tasks/set_defaults.yml
@@ -5,4 +5,3 @@
     tas_single_node_fulcio: "{{ _tas_single_node_fulcio | combine(tas_single_node_fulcio | default({}, true), recursive=true) }}"
     tas_single_node_ingress_certificates: >-
       {{ _tas_single_node_ingress_certificates | combine(tas_single_node_ingress_certificates | default({}, true), recursive=true) }}
-      

--- a/roles/tas_single_node/tasks/set_defaults.yml
+++ b/roles/tas_single_node/tasks/set_defaults.yml
@@ -3,6 +3,5 @@
   ansible.builtin.set_fact:
     tas_single_node_tsa: "{{ _tas_single_node_tsa | combine(tas_single_node_tsa | default({}, true), recursive=true) }}"
     tas_single_node_fulcio: "{{ _tas_single_node_fulcio | combine(tas_single_node_fulcio | default({}, true), recursive=true) }}"
-    tas_single_node_ingress_certificates: "{{ _tas_single_node_ingress_certificates | combine(tas_single_node_ingress_certificates | default({}, true), recursive=true) }}"
-
-
+    tas_single_node_ingress_certificates: >-
+      {{ _tas_single_node_ingress_certificates | combine(tas_single_node_ingress_certificates | default({}, true), recursive=true) }}

--- a/roles/tas_single_node/tasks/set_defaults.yml
+++ b/roles/tas_single_node/tasks/set_defaults.yml
@@ -5,3 +5,4 @@
     tas_single_node_fulcio: "{{ _tas_single_node_fulcio | combine(tas_single_node_fulcio | default({}, true), recursive=true) }}"
     tas_single_node_ingress_certificates: >-
       {{ _tas_single_node_ingress_certificates | combine(tas_single_node_ingress_certificates | default({}, true), recursive=true) }}
+      

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -1,4 +1,52 @@
 ---
+# vars file for tas_single_node
+_tas_single_node_tsa: 
+  signer_type: file
+  certificate:
+    organization_name: ""
+    organization_email: ""
+    common_name: ""
+  kms:
+    key_resource: ""
+  tink:
+    key_resource: ""
+    keyset: ""
+    hcvault_token: ""
+  signer_private_key: ""
+  certificate_chain: ""
+  signer_passphrase: rhtas
+  ca_passphrase: rhtas
+  ntp_config: ""
+
+_tas_single_node_fulcio: 
+  certificate:
+    organization_name: ""
+    organization_email: ""
+    common_name: ""
+  private_key: ""
+  root_ca: ""
+
+_tas_single_node_ingress_certificates:
+  fulcio:
+    certificate: ""
+    private_key: ""
+  rekor:
+    certificate: ""
+    private_key: ""
+  tuf:
+    certificate: ""
+    private_key: ""
+  tsa:
+    certificate: ""
+    private_key: ""
+  rekor-search:
+    certificate: ""
+    private_key: ""
+  cli-server:
+    certificate: ""
+    private_key: ""
+
+
 # vars file for sigstore_scaffolding
 tas_single_node_system_packages:
   - podman

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # vars file for tas_single_node
-_tas_single_node_tsa: 
+_tas_single_node_tsa:
   signer_type: file
   certificate:
     organization_name: ""
@@ -18,7 +18,7 @@ _tas_single_node_tsa:
   ca_passphrase: rhtas
   ntp_config: ""
 
-_tas_single_node_fulcio: 
+_tas_single_node_fulcio:
   certificate:
     organization_name: ""
     organization_email: ""


### PR DESCRIPTION
This pull request addresses the issue where the user-provided values for nested dictionaries in the **tas_single_node** role override the entire dictionary causing other values to become undefined.
The changes ensures that the default values are properly combined and executed properly.

-  Remove all such defaults from defaults/main.yml

- Add them with a slightly changed name (e.g. prefixed with underscore) to vars/main.yml

-  Add a new task file (imported from tasks/main.yml right at the start) that will include tasks that properly combine our and user-provided values, e.g.: 
