### PR TITLE
:robot: [RHTAS-build-bot] [main] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -109,23 +109,23 @@ tas_single_node_ctlog_ca_passphrase: rhtas
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:f58588d336b578da548831d555d627614eabf993a693f570047c2a2bafff5b1b"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:e998c91223ae47e69486e6204f42b8d2f295c8bf9e2c6feea4c4b64918728d48"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:89eec6d832ff3cd032ace453f950c88b075994e5b905d5347fd927202876c512"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:24b253a5935addd15bf0ef4b5ec4a1289904cbcbc1c7807cb537a1aa476dc4e0"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:0a9713466a55b5c79eae8dce71fd33184fdd07e59ffd530ca17b60895374902c"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:d018189165914a55b501d8382bd32623937028dc406f1a27d9fedf98bc9d0b5a"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:993394a07f178f89eb103b33fbf7bc007db3cca98eaa79e01b6e6a1ba2a302e6"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:20002736dd2620dc901449acf680b6f6e7f47f0422cdade5de4c8564274e060e"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:5e85b4eb162c1d136add09491af72413a5d7475df041ce4340b919302bee6600"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:47948b7852bcca09015e5fd264c7c30d5c79bce0e365cd69438ef0b9a1d52a9f"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:0b708607468e175139de6838b90b7fa2fb22985e2f0e8caa81e0f97b0a1a590c"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:02b4b7af366c6cda6b0ae0a9559936b65141c4e866ec7953b46f24afb737a6a7"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:59b06a2fc7290b0dd7738f09c0d3fe19eab69f2bea10c998c481da3139c25c78"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:631cebd3f08ccaba66a7a16f20f87af6c921810d1671a69e39c26dfd6f63d6f4"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:614ba2e79a5f5230bea925d001756c66ac09deac24aa529628095540d8219180"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:1457e4ecc16a9fb6d93994dddecba2bd5dd2c32974dbb55d97b610e8446e4110"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:c327853589a048b0848773bc19e74edc598498eda2021914e92b4fcfd1059a02"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:f809a7147af3caffb9dd7212c3dc327f5a5944e227fd590a2a659900f4b44b64"
 tas_single_node_http_server_image:
   "registry.access.redhat.com/ubi9/httpd-24@sha256:7874b82335a80269dcf99e5983c2330876f5fe8bdc33dc6aa4374958a2ffaaee"
 tas_single_node_trillian_netcat_image:
@@ -133,15 +133,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:71fc4492c3a632663c1e17ec9364d87aa7bd459d3c723277b8b94a949b84c9fe"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:0fdd5e119325e8c30f5ef0da9b0a78469143a3d222e8b92d0d972acbed8db99c"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:916d130bee192a029e09ebdc2546ba3acd28879b6f7c3c69c5c804de3d65d60a"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:1432b47ddd881eb1909453e939c791825e7853b4abc00a12dddd948f99022ab3"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:eaa4c0e539930fc5f007752a5b19d82cf4de7ad11502124ee185d5c3990c3628"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/trillian-createtree-rhel9@sha256:43da71295323660fd9992e3ba2e2ad63ed9f729dbb42401e041ad02c73da718a"
+  "registry.redhat.io/rhtas/trillian-createtree-rhel9@sha256:c8de68bf2ebd4a026e48b533b2fa3ea300d6e77020feed9f6f7fb498a5ba5a6b"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:ce30450e9e3aee7368bd9ba7f756d7af0f7c0e052cd57951256adaa9c78fb562"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:58ed61e60fb8447fa9c9af4996efe612ed3220f291c9e190cfbb785df0585410"
 
 tas_single_node_podman: {}
 


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `1432b47` | `eaa4c0e` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `f58588d` | `e998c91` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `5e85b4e` | `47948b7` |
| registry.redhat.io/rhtas/trillian-createtree-rhel9 | `43da712` | `c8de68b` |
| registry.redhat.io/rhtas/client-server-rhel9 | `ce30450` | `58ed61e` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `0fdd5e1` | `916d130` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `993394a` | `2000273` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `89eec6d` | `24b253a` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `614ba2e` | `1457e4e` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `59b06a2` | `631cebd` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `0a97134` | `d018189` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `c327853` | `f809a71` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `0b70860` | `02b4b7a` |
---