### PR TITLE
:robot: [RHTAS-build-bot] [main] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -21,23 +21,23 @@ tas_single_node_trust_root:
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:e998c91223ae47e69486e6204f42b8d2f295c8bf9e2c6feea4c4b64918728d48"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:20beb191625ac369b836b587735275235f0aa53c2cd16130f011c3bf886b8f26"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:9101809aa904530d51e592576707932e0da96a3be4d4ecc03f9bcabc0db8d7a6"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:76c24a38ac89ed632d38e44049f37e4997abfa27fa8cadbb8afb42575031296f"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:c499438e52f4c6bf09dcb28761cbd1a1d08ca0c3c07f66c205e316f36bf54e2d"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:1f5a30a285a16635a7234c3c1763dfb385c8bffd605fc862b782bdb5c6c61ea3"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:20002736dd2620dc901449acf680b6f6e7f47f0422cdade5de4c8564274e060e"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:3b8f49c41df15022f8ffdf3a8f8605b14c14f4e10eae754a06a86b6585d158b3"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:47948b7852bcca09015e5fd264c7c30d5c79bce0e365cd69438ef0b9a1d52a9f"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:dc994a95be22b0f4bab022fc362c4f44c6a7d1887a2eb0d04870d75654ec013b"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:02b4b7af366c6cda6b0ae0a9559936b65141c4e866ec7953b46f24afb737a6a7"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:5a752cefdaf28bfc53847185cdd5fef1ee47e3dcff8472f8a8bf7bbdc224ef57"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:631cebd3f08ccaba66a7a16f20f87af6c921810d1671a69e39c26dfd6f63d6f4"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:6131053778ea04e437f3005f90d1138aa11ebc58e3a9295e2a8d8ef6713a52be"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:1457e4ecc16a9fb6d93994dddecba2bd5dd2c32974dbb55d97b610e8446e4110"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:7ce611aefdfedd8b2a633def482cf41f390c95b8f8c800b6163a585f117a9e2e"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:f809a7147af3caffb9dd7212c3dc327f5a5944e227fd590a2a659900f4b44b64"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:775b261b8f258b369213246f2da5c91218678acb5e3b8bb4670b143f487767af"
 tas_single_node_http_server_image:
   "registry.access.redhat.com/ubi9/httpd-24@sha256:7874b82335a80269dcf99e5983c2330876f5fe8bdc33dc6aa4374958a2ffaaee"
 tas_single_node_trillian_netcat_image:
@@ -45,14 +45,14 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:71fc4492c3a632663c1e17ec9364d87aa7bd459d3c723277b8b94a949b84c9fe"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:916d130bee192a029e09ebdc2546ba3acd28879b6f7c3c69c5c804de3d65d60a"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:796860a3e85712c60398c36983e0ff4d45325c7a4de869da2ebf1b6ba4b19825"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:20cc688c02d78c44e6706836179b6d6c9ddc9811d1d6315fcd5c900b65d48fd8"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:254842bb8a2a1f22f28d690ae86a05a52789dabb13b5be4b32c416c77b6cb5ae"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:777243778cc202d317b9350773b1faff33e99325b837b69e398f80e9479dae13"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:d9ff8413f1d106cb5084b48b73b205db6dd5ad82818be4111c5cb118d9d135ae"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:58ed61e60fb8447fa9c9af4996efe612ed3220f291c9e190cfbb785df0585410"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:75f1049431f9e92898a4217870309cbbb3b39c8362e929c0bad3b53cad4459db"
 
 tas_single_node_podman: {}


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `20cc688` | `254842b` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `e998c91` | `20beb19` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `47948b7` | `dc994a9` |
| registry.redhat.io/rhtas/createtree-rhel9 | `7772437` | `d9ff841` |
| registry.redhat.io/rhtas/client-server-rhel9 | `58ed61e` | `75f1049` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `916d130` | `796860a` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `2000273` | `3b8f49c` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `9101809` | `76c24a3` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `1457e4e` | `7ce611a` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `631cebd` | `6131053` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `c499438` | `1f5a30a` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `f809a71` | `775b261` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `02b4b7a` | `5a752ce` |
---