### PR TITLE
SECURESIGN-2051 - missing required arguments: password found in tas_single_node_cockpit -> user

### DIFF
--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -268,7 +268,7 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 |---|---|---|---|---|
 | create | Whether or not to create the cockpit user. | bool | no |  |
 | username | Username for the cockpit user. | str | no |  |
-| password | Password for the cockpit user. | str | yes |  |
+| password | Password for the cockpit user. | str | no |  |
 
 #### Options for main > tas_single_node_trust_root
 

--- a/roles/tas_single_node/meta/argument_specs.yml
+++ b/roles/tas_single_node/meta/argument_specs.yml
@@ -770,7 +770,7 @@ argument_specs:
               password:
                 description: "Password for the cockpit user."
                 type: "str"
-                required: true
+                required: false
                 version_added: "1.2.0"
       tas_single_node_podman_volume_create_extra_args:
         description: >


### PR DESCRIPTION
Pr to fix https://issues.redhat.com/browse/SECURESIGN-2051