### PR TITLE
Add explicit dependency on the ansible.posix collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,8 @@ description: Install and configure RHTAS, a downstream redistribution of the Sig
 license_file: LICENSE
 tags: [sigstore, tas, rhtas, security, cosign]
 # NOTE: when updating, also update dependencies in requirements.yml
-dependencies: {}
+dependencies:
+  ansible.posix: ">=1.5.4"
 repository: https://github.com/securesign/artifact-signer-ansible/
 documentation: https://docs.redhat.com/en/documentation/red_hat_trusted_artifact_signer
 homepage: https://github.com/securesign/artifact-signer-ansible#rhtas-ansible-collection

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,5 @@
 ---
 # NOTE: when updating, also update dependencies in galaxy.yml
-collections: []
+collections:
+  - name: ansible.posix
+    version: ">=1.5.4"


### PR DESCRIPTION
We need this dependency for the backup/restore machinery as well as for enabling custom trust root upload. As the minimum dep version I chose 1.5.4 - I tested with it and it seems fine, the newer versions seem to preserve backwards compability for the tasks we're using.