### PR TITLE
[SECURESIGN-1856] Update to Make Sure Verbose Output in Ansible doesnt print Secrets/Keys 

### DIFF
--- a/roles/tas_single_node/tasks/set_defaults.yml
+++ b/roles/tas_single_node/tasks/set_defaults.yml
@@ -12,3 +12,4 @@
     tas_single_node_tsa: "{{ _tas_single_node_tsa | combine(tas_single_node_tsa | default({}, true), recursive=true) }}"
     tas_single_node_ctlog: "{{ _tas_single_node_ctlog | combine(tas_single_node_ctlog | default({}, true), recursive=true) }}"
     tas_single_node_cockpit: "{{ _tas_single_node_cockpit | combine(tas_single_node_cockpit | default({}, true), recursive=true) }}"
+  no_log: true


### PR DESCRIPTION
Inside the new `set_defaults.yml` file the `Set default values for_tas_single_node var`  task is setting new Ansible facts and outputs which includes sensitive information. This is a small update fix to address that.