### PR TITLE
Deleting redundant verify action

### DIFF
--- a/.github/actions/molecule-test/action.yaml
+++ b/.github/actions/molecule-test/action.yaml
@@ -39,7 +39,7 @@ runs:
         echo "$AWS_SSH_KEY" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
 
-    - name: Run molecule converge
+    - name: Run molecule test
       shell: bash
       run: |
         source venv/bin/activate

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -27,15 +27,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install TAS using molecule converge
-        uses: ./.github/actions/molecule-converge
+      - name: Install TAS using molecule test
+        uses: ./.github/actions/molecule-test
         with:
           scenario: ${{ matrix.scenario }}
-
-      - name: Molecule verify
-        run: |
-          source venv/bin/activate
-          molecule -v verify --scenario-name ${{ matrix.scenario }}
 
       - name: Extract TAS IP address
         run: |


### PR DESCRIPTION
`molecule-test` already includes the verify manifest, no point in running it again.