### PR TITLE
Test tas_single_node_meta_issueers

### DIFF
--- a/molecule/common/verify_common.yml
+++ b/molecule/common/verify_common.yml
@@ -48,7 +48,6 @@
     env:
       BASE_HOSTNAME: "{{ tas_single_node_base_hostname }}"
       EMAIL: "kilgore@kilgore.trout"
-      KEYCLOAK_URL: "https://{{ tas_single_node_oidc_issuers[0].url | urlsplit('hostname') }}"
       OIDC_ISSUER_URL: "http://dex-idp:5556/dex"
     # NOTE: we can't add hosts with the etc_hosts parameter, because we would need to template
     # the dictionary keys for it and Ansible doesn't do that

--- a/molecule/test/test-sign-blob.sh
+++ b/molecule/test/test-sign-blob.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-# NOTE: this script requires BASE_HOSTNAME and KEYCLOAK_URL to be set
+# NOTE: this script requires BASE_HOSTNAME
 
 # extract the root certificate and make it trusted
 script_dir="$(dirname "$(readlink -f "$0")")"

--- a/molecule/user_provided/vars/vars.yml
+++ b/molecule/user_provided/vars/vars.yml
@@ -1,6 +1,5 @@
-tas_single_node_oidc_issuers:
-  - issuer: "http://dex-idp:5556/dex"
-    url: "http://dex-idp:5556/dex"
+tas_single_node_meta_issuers:
+  - issuer_pattern: "http://dex-*:5556/dex"
     client_id: example-app
     type: email
 tas_single_node_base_hostname: myrhtas


### PR DESCRIPTION
We have test coverage for `tas_single_node_oidc_issuers` in the `default` scenario. Let's cover the `tas_single_node_meta_issuers` in the `user_provided`.