### PR TITLE
Rename the rekor pubkey in the TUF repository

### DIFF
--- a/roles/tas_single_node/tasks/podman/tuf.yml
+++ b/roles/tas_single_node/tasks/podman/tuf.yml
@@ -41,7 +41,7 @@
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ctlog_public_key.0) | list | first).content }}
         fulcio_v1.crt.pem: |
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_fulcio_root_ca) | list | first).content }}
-        rekor-pubkey: |
+        rekor.pub: |
           {{ rekor_public_key_result.stdout | b64encode }}
         tsa.certchain.pem: |
           {{ (remote_tuf_certificates.results | selectattr('source', 'equalto', tas_single_node_tsa_certificate_chain) | list | first).content }}

--- a/roles/tas_single_node/templates/manifests/tuf/tuf-init.j2
+++ b/roles/tas_single_node/templates/manifests/tuf/tuf-init.j2
@@ -34,7 +34,7 @@ spec:
               /usr/bin/tuf-repo-init.sh
               --export-keys file:///var/run/tuf-signing-keys
 {% if tas_single_node_rekor_enabled %}
-              --rekor-key /var/run/tuf-secrets/rekor-pubkey
+              --rekor-key /var/run/tuf-secrets/rekor.pub
 {% endif %}
 {% if tas_single_node_ctlog_enabled %}
               --ctlog-key /var/run/tuf-secrets/ctfe.pub


### PR DESCRIPTION
This PR improves the name of rekor public key in the TUF repository to be more in line with the rotation docs.