### PR TITLE
Disable molecule prerun

### DIFF
--- a/molecule/aap-test/molecule.yml
+++ b/molecule/aap-test/molecule.yml
@@ -1,4 +1,5 @@
 ---
+prerun: false
 dependency:
   name: galaxy
   options:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,4 +1,5 @@
 ---
+prerun: false
 dependency:
   name: galaxy
   options:

--- a/molecule/user_provided/molecule.yml
+++ b/molecule/user_provided/molecule.yml
@@ -1,4 +1,5 @@
 ---
+prerun: false
 dependency:
   name: galaxy
   options:


### PR DESCRIPTION
```
To help Ansible find used modules and roles, molecule will perform a prerun set of actions. These involve installing dependencies from requirements.yml specified at the project level, installing a standalone role or a collection. The destination is project_dir/.cache and the code itself was reused from ansible-lint, which has to do the same actions. (Note: ansible-lint is not included with molecule.)

This assures that when you include a role inside molecule playbooks, Ansible will be able to find that role and that the include is exactly the same as the one you are expecting to use in production.

If for some reason the prerun action does not suit your needs, you can still disable it by adding prerun: false inside the configuration file.

Keep in mind that you can add this value to the .config/molecule/config.yml file, in your $HOME or at the root of your project, in order to avoid adding it to each scenario.
```
https://ansible.readthedocs.io/projects/molecule/configuration/?h=prerun#prerun

The `prerun` phase builds the project itself and install it into galaxy collections local repository. That feature can be useful when you want to test collection as it is used in production but we do not do that. We use ` ANSIBLE_ROLES_PATH: "../../roles" env to redirect the ansible role loader and then we use a different name than we have in production (`tas_single_node`/`redhat.artifact_signer.tas_single_node`).

The problem is, that the `prerun` phase overrides the already installed collection (`dev` build), so I would like to disable it.

