### PR TITLE
Fixing systemd template formatting for container teardown and broken deployment restoration

### DIFF
--- a/roles/tas_single_node/tasks/podman/install_manifest.yml
+++ b/roles/tas_single_node/tasks/podman/install_manifest.yml
@@ -44,7 +44,8 @@
   when: |
     copy_manifest.changed or copy_systemd_file.changed or
     (podman_spec.secret is defined and podman_spec.secret_changed) or
-    (podman_spec.configmap is defined and podman_spec.configmap_changed)
+    (podman_spec.configmap is defined and podman_spec.configmap_changed) or
+    tas_single_node_backup_restore.restore.enabled
   register: podman_service_restart
 
 # We do all this because checking exit status of the container by the systemd unit has only been added in podman 4.6.0

--- a/roles/tas_single_node/templates/systemd/systemd.j2
+++ b/roles/tas_single_node/templates/systemd/systemd.j2
@@ -17,7 +17,7 @@ ExecStart=/usr/bin/podman kube play --replace --service-container=true "{{ kube_
 * if this is a oneshot job, we want to keep the pod around for possible failure inspection, so we remove it next time we start the job (ExecStartPre)
 * if this is a regular service, we remove the pod when shutting down (ExecPost)
 #}
-Exec{% if "systemd_type" in podman_spec and podman_spec.systemd_type == "oneshot" %}StartPre=-{% else %}Stop={% endif %}/usr/bin/podman stop "{{ podman_spec.kube_file_content.metadata.name }}-pod-{{ podman_spec.kube_file_content.spec.template.spec.containers[0].name }}" && /usr/bin/podman kube down "{{ kube_play_file }}"
+Exec{% if "systemd_type" in podman_spec and podman_spec.systemd_type == "oneshot" %}StartPre=-{% else %}Stop={% endif %}/bin/bash -c "/usr/bin/podman stop {{ podman_spec.kube_file_content.metadata.name }}-pod-{{ podman_spec.kube_file_content.spec.template.spec.containers[0].name }} && /usr/bin/podman kube down {{ kube_play_file }}"
 Type={{ podman_spec.systemd_type | default('notify') }}
 NotifyAccess=all
 


### PR DESCRIPTION
1. Formatting for stopping containers and tearing down pod was faulty - Fixed. (Pod stopped first to get rid of runtime artifacts incase of backup, worked but second part for teardown did not because systemd commands are not ran in shell)

2. Incase of faulty deployment, added a restore.enabled check when restarting podman service since initially it would not, leaving behand broken pod remnants. (Complete manual teardown to ensure a mimic of a 'fresh node' documented in notes for Aron)