### PR TITLE
ci: add tekton build pipelines

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,6 @@
 ---
 exclude_paths:
   - .github
+  - .tekton
   - molecule
   - vm-testing

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/securesign/artifact-signer-ansible?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && (".tekton/pull-request.yaml".pathChanged() || "Dockerfile".pathChanged()
+      || "roles/***".pathChanged() || "meta/***".pathChanged()
+      || "requirements.json".pathChanged()
+  labels:
+    appstudio.openshift.io/application: ansible-main
+    appstudio.openshift.io/component: ansible-collection-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ansible-collection-on-pull-request
+  namespace: rhtas-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/securesign/ansible-collection:on-pr-{{revision}}
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: ''
+  - name: image-expires-after
+    value: 5d
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/securesign/pipelines.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/docker-build-oci-ta.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ansible-collection-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/securesign/artifact-signer-ansible?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && (".tekton/push.yaml".pathChanged() || "Dockerfile".pathChanged()
+      || "roles/***".pathChanged() || "meta/***".pathChanged()
+      || "requirements.json".pathChanged()
+  labels:
+    appstudio.openshift.io/application: ansible-main
+    appstudio.openshift.io/component: ansible-collection-main
+    pipelines.appstudio.openshift.io/type: build
+  name: ansible-collection-on-push
+  namespace: rhtas-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/securesign/ansible-collection:{{revision}}
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: ''
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/securesign/pipelines.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/docker-build-oci-ta.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ansible-collection-main
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary by Sourcery

Introduce Tekton PipelineRun configurations to automate building and publishing the Ansible collection image on pull request and push events targeting the main branch.

CI:
- Add .tekton/pull-request.yaml to define a Tekton pipeline for PR-based builds with path-based triggers
- Add .tekton/push.yaml to define a Tekton pipeline for push-based builds with path-based triggers