### PR TITLE
fix: Accept ingress certs provided without ending newline

### DIFF
--- a/roles/tas_single_node/tasks/podman/nginx.yml
+++ b/roles/tas_single_node/tasks/podman/nginx.yml
@@ -38,50 +38,56 @@
 
 - name: Base64 encode the rekor ingress
   ansible.builtin.set_fact:
-    rekor_ingress_base64: >-
+    rekor_ingress_base64: |-
       {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-rekor.pem') | list | first).content
-      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
-      | b64decode }}
+      | b64decode | trim }}
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode | trim }}
   no_log: true
 
 - name: Base64 encode the rekor ingress
   ansible.builtin.set_fact:
-    rekor_search_ingress_base64: >-
+    rekor_search_ingress_base64: |-
       {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-rekor-search.pem') | list | first).content
-      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
-      | b64decode }}
+      | b64decode | trim }}
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode | trim }}
   no_log: true
 
 - name: Base64 encode the tuf ingress
   ansible.builtin.set_fact:
-    tuf_ingress_base64: >-
+    tuf_ingress_base64: |-
       {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tuf.pem') | list | first).content
-      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
-      | b64decode }}
+      | b64decode | trim }}
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode | trim }}
   no_log: true
 
 - name: Base 64 encode the fulcio ingress
   ansible.builtin.set_fact:
-    fulcio_ingress_base64: >-
+    fulcio_ingress_base64: |-
       {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-fulcio.pem') | list | first).content
-      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
-      | b64decode }}
+      | b64decode | trim }}
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode | trim }}
   no_log: true
 
 - name: Base 64 encode the tsa ingress
   ansible.builtin.set_fact:
-    tsa_ingress_base64: >-
+    tsa_ingress_base64: |-
       {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-tsa.pem') | list | first).content
-      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
-      | b64decode }}
+      | b64decode | trim }}
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode | trim }}
   no_log: true
 
 - name: Base 64 encode the cli server ingress
   ansible.builtin.set_fact:
-    cli_server_ingress_base64: >-
+    cli_server_ingress_base64: |-
       {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_certs_dir + '/ingress-cli-server.pem') | list | first).content
-      | b64decode + (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
-      | b64decode }}
+      | b64decode | trim }}
+      {{ (remote_ingress_certificates.results | selectattr('source', 'equalto', tas_single_node_remote_ca) | list | first).content
+      | b64decode | trim }}
   no_log: true
 
 - name: Create nginx certs Secret


### PR DESCRIPTION
This will make the role accept ingress certs defined like this:

```
      cli-server:
        certificate: "{{ lookup('file', 'ingress-cli-server.pem') }}"
        private_key: "{{ lookup('file', 'ingress-cli-server.key') }}"
```

in addition to the currently working definition:

```
      rekor:
        certificate: |
          {{ lookup('file', 'ingress-rekor.pem') }}
        private_key: |
          {{ lookup('file', 'ingress-rekor.key') }}
```

The cause of the bug was that the first definition of variables wouldn't contain trailing newline. The code that combined the cert with the root cert would then create a pem file containing line `-----END CERTIFICATE----------BEGIN CERTIFICATE-----` which caused SSL error as an invalid cert.

## Summary by Sourcery

Ensure ingress TLS certificates lacking a final newline are handled correctly by trimming decoded content before concatenation to avoid malformed PEM files.

Bug Fixes:
- Trim decoded ingress and CA certificate contents to prevent PEM boundary collisions when certs omit a trailing newline.

Enhancements:
- Convert all Nginx Ansible set_fact tasks for ingress certs to use literal block style with the trim filter for clearer decoding logic.