### PR TITLE
fix: Check all used CI Issuers are present

### DIFF
--- a/roles/tas_single_node/tasks/configuration_check.yml
+++ b/roles/tas_single_node/tasks/configuration_check.yml
@@ -13,7 +13,8 @@
 
 - name: Check CI Issuer Metadata
   ansible.builtin.fail:
-    msg: All tas_single_node_fulcio.fulcio_config.{{ item }}.ci_provider must be present in tas_single_node_fulcio.ci_issuer_metadata
+    msg: "All tas_single_node_fulcio.fulcio_config.{{ item }}.ci_provider must be present in tas_single_node_fulcio.ci_issuer_metadata: {{
+        (used_ci_issuers[item] | difference(defined_ci_issuers)) | join(', ') }}"
   when: >-
     used_ci_issuers[item] | difference(defined_ci_issuers) | length > 0
   loop: ["oidc_issuers", "meta_issuers"]


### PR DESCRIPTION
This is a followup to https://github.com/securesign/artifact-signer-ansible/pull/292 which will ensure that all CI Issuers used from OIDC Issuers/Meta Issuers are defined in CI Issuer Metadata.

## Summary by Sourcery

Enhancements:
- Add Ansible tasks to collect all used CI issuers and verify they exist in ci_issuer_metadata for both OIDC and Meta issuers