### PR TITLE
Fix AAP CI

### DIFF
--- a/molecule/aap-test/converge.yml
+++ b/molecule/aap-test/converge.yml
@@ -164,8 +164,7 @@
       delegate_to: localhost
       block:
         - name: Include role to add subscription to controller
-          ansible.builtin.include_role:
-            name: infra.aap_configuration.controller_license
+          ansible.builtin.include_tasks: files/subscription.yml
           vars:
             controller_dependency_check: true
             aap_hostname: "{{ aap_instance_ip }}"
@@ -177,7 +176,9 @@
             aap_request_timeout: 900
             controller_license:
               use_lookup: true
-              force: true
+              filters:
+                product_name: "Red Hat Ansible Automation Platform"
+                support_level: "Self-Support"
 
     - name: Create project for TAS single node playbook
       delegate_to: localhost

--- a/molecule/aap-test/files/subscription.yml
+++ b/molecule/aap-test/files/subscription.yml
@@ -1,0 +1,34 @@
+---
+
+- name: subscription | Get subscriptions with a filter
+  ansible.controller.subscriptions:
+    client_id: "{{ redhat_subscription_username }}"
+    client_secret: "{{ redhat_subscription_password }}"
+    filters: "{{ controller_license.filters }}"
+    # Role Standard Options
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  register: subscription
+  when:
+    - "'use_lookup' in controller_license"
+    - controller_license.use_lookup
+
+- name: subscription | Install the Controller license
+  ansible.controller.license:
+    subscription_id: "{{ controller_license.pool_id | default(subscription.subscriptions[(controller_license.list_num | default(0))].subscription_id) }}"
+    force: "{{ controller_license.force | default(omit) }}"
+    state: "{{ controller_license.state | default(omit) }}"
+
+    # Role Standard Options
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  when: controller_license is defined
+...


### PR DESCRIPTION
This is due to change in `infra.aap_configuration` and latest version.
Related Issues: 
https://github.com/redhat-cop/infra.aap_configuration/issues/1102
https://github.com/redhat-cop/infra.aap_configuration/issues/1068

## Summary by Sourcery

Fix the Molecule AAP CI converge playbook by replacing the deprecated controller_license role with a custom task sequence and align subscription handling with the latest infra.aap_configuration changes.

Bug Fixes:
- Swap inclusion of infra.aap_configuration.controller_license role for an include_tasks call to a new subscription.yml file
- Add filters for subscription lookup instead of forcing license install
- Introduce subscription.yml to fetch subscriptions and apply controller license via ansible.controller modules