### PR TITLE
test: Multiple OIDCs configuration

### DIFF
--- a/molecule/default/vars/vars.yml
+++ b/molecule/default/vars/vars.yml
@@ -5,6 +5,10 @@ tas_single_node_fulcio:
         url: "http://dex-idp:5556/dex"
         client_id: trusted-artifact-signer
         type: email
+      - issuer: "sigstore"
+        url: "https://oauth2.sigstore.dev/auth"
+        client_id: sigstore
+        type: email
 tas_single_node_base_hostname: myrhtas
 tas_single_node_cockpit:
   enabled: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -7,6 +7,24 @@
   vars_files:
     - vars/vars.yml
   tasks:
+    - name: Multiple OIDCs are configured
+      block:
+        - name: Slurp fulcio config
+          ansible.builtin.slurp:
+            src: "/etc/rhtas/configs/fulcio-config.yaml"
+          register: fulcio_config
+        - name: Assert the sigstore is instance present
+          ansible.builtin.assert:
+            that:
+              - fulcio_config
+              - "'https://oauth2.sigstore.dev/auth' in (fulcio_config.content | b64decode)"
+            fail_msg: "The sigstore endpoint was not found in fulcio config"
+        - name: Assert the DEX is instance present
+          ansible.builtin.assert:
+            that:
+              - fulcio_config
+              - "'http://dex-idp:5556/dex' in (fulcio_config.content | b64decode)"
+            fail_msg: "The DEX endpoint was not found in fulcio config"
     - name: Include create common tasks
       ansible.builtin.include_tasks:
         file: ../common/verify_common.yml

--- a/molecule/test/Containerfile
+++ b/molecule/test/Containerfile
@@ -1,14 +1,6 @@
-FROM fedora:40
+FROM ghcr.io/sigstore/cosign/cosign:latest as cosign-bin
 
+FROM fedora:40
 RUN dnf install -y openssl vim && dnf clean all
 
-ARG TARGETARCH
-RUN \
-  LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | grep tag_name | cut -d : -f2 | tr -d "v\", ") && \
-  if [ "$TARGETARCH" = "arm64" ]; then \
-    RPM_URL="https://github.com/sigstore/cosign/releases/latest/download/cosign-${LATEST_VERSION}-1.aarch64.rpm"; \
-  else \
-    RPM_URL="https://github.com/sigstore/cosign/releases/latest/download/cosign-${LATEST_VERSION}-1.x86_64.rpm"; \
-  fi && \
-  curl -O -L "$RPM_URL" && \
-  rpm -ivh "$(basename "$RPM_URL")"
+COPY --from=cosign-bin /ko-app/cosign /usr/local/bin/cosign


### PR DESCRIPTION
## Summary by Sourcery

Add configuration support and verification tests for multiple OIDC issuers in Fulcio configuration

New Features:
- Allow configuring multiple OIDC issuers for Fulcio

Enhancements:
- Include a new 'sigstore' issuer entry in the default vars for OIDC configuration

Tests:
- Add Molecule verify tasks to slurp the Fulcio config and assert both DEX and Sigstore endpoints are present