### PR TITLE
add ci-issuer-metadata to aap-test vars

### DIFF
--- a/molecule/aap-test/converge.yml
+++ b/molecule/aap-test/converge.yml
@@ -324,6 +324,7 @@
                           client_id: trusted-artifact-signer
                           type: email
                       meta_issuers: []
+                      ci_issuer_metadata: []
                   tas_single_node_base_hostname: myrhtas
                   tas_single_node_registry_username: "{{ lookup('env', 'TAS_SINGLE_NODE_REGISTRY_USERNAME') }}"
                   tas_single_node_registry_password: "{{ lookup('env', 'TAS_SINGLE_NODE_REGISTRY_PASSWORD') }}"


### PR DESCRIPTION
Change needed after: https://github.com/securesign/artifact-signer-ansible/pull/292
AAP build example ✅ : https://github.com/securesign/artifact-signer-ansible/actions/runs/16415412777/job/46380109295?pr=281

## Summary by Sourcery

Tests:
- Include an empty ci_issuer_metadata list in the aap-test converge.yml variables