### PR TITLE
fix CI: fix ansible-lint, use specific infra.aap_utilities for AAP

### DIFF
--- a/molecule/aap-test/converge.yml
+++ b/molecule/aap-test/converge.yml
@@ -22,15 +22,15 @@
 
     aap_setup_prep_inv_nodes:
       automationcontroller:
-        127.0.0.1:
+        - "127.0.0.1"
       automationhub:
-        127.0.0.1:
+        - "127.0.0.1"
       database:
-        127.0.0.1:
+        - "127.0.0.1"
       automationgateway:
-        127.0.0.1:
+        - "127.0.0.1"
       automationeda:
-        127.0.0.1:
+        - "127.0.0.1"
     aap_setup_prep_inv_vars:
       all:
         ansible_user: "ec2-user"

--- a/molecule/aap-test/requirements.yml
+++ b/molecule/aap-test/requirements.yml
@@ -3,11 +3,12 @@
 ---
 
 collections:
-  - community.crypto
-  - containers.podman
-  - amazon.aws
-  - ansible.controller
-  - ansible.platform
-  - infra.aap_utilities
-  - infra.ah_configuration
-  - infra.aap_configuration
+  - name: community.crypto
+  - name: containers.podman
+  - name: amazon.aws
+  - name: ansible.controller
+  - name: ansible.platform
+  - name: infra.aap_utilities
+    version: 2.6.1
+  - name: infra.ah_configuration
+  - name: infra.aap_configuration

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,3 +1,4 @@
+ansible>=8.0.0,<9.0.0
 ansible-lint==25.1.2
 antsibull-docs==2.19.1
 awscli==1.40.31

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,4 +1,4 @@
-ansible>=8.0.0,<9.0.0
+ansible-core>=2.16.0,<2.19.0
 ansible-lint==25.1.2
 antsibull-docs==2.19.1
 awscli==1.40.31


### PR DESCRIPTION
## Summary by Sourcery

Fix ansible-lint job.
Fix AAP CI by specifying the infra.aap_utilities collection version and correcting inventory format in the molecule test configuration

Bug Fixes:
- Pin the infra.aap_utilities collection to version 2.6.1 in molecule/aap-test/requirements.yml to satisfy CI dependencies
- Fix inventory host definitions in molecule/aap-test/converge.yml by converting bare IP mappings to lists of strings

Enhancements:
- Standardize Ansible collection entries in molecule/aap-test/requirements.yml using explicit name fields