### PR TITLE
feat(SECURESIGN-1618): Implement configuration of Rekor attestation storage

### DIFF
--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -238,6 +238,7 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 | private_keys | List of private keys for use within rekor. | list of dicts of 'private_keys' options | no |  |
 | public_keys | List of public keys for use within rekor. | list of dicts of 'public_keys' options | no |  |
 | sharding_config | Sharding configuration for rekor | list of dicts of 'sharding_config' options | no |  |
+| attestations | Configuration for Rekor attestation storage. | dict of 'attestations' options | no |  `{'enabled': True, 'url': 'file:///var/run/attestations?no_tmp_dir=true', 'max_size': '100000'}`  |
 
 #### Options for main > tas_single_node_rekor > kms
 
@@ -274,6 +275,14 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 | tree_length | Length of rekor tree. | str | no |  |
 | signing_config | Signing Configuration or rekor shard. | str | no |  |
 | pem_pub_key | ID of custom key provided to rekor. | str | no |  |
+
+#### Options for main > tas_single_node_rekor > attestations
+
+|Option|Description|Type|Required|Default|
+|---|---|---|---|---|
+| enabled | Enable Rekor attestation storage. | bool | no |  |
+| url | Url of the storage location, supports go-cloud blob URLs. The 'file:///var/run/attestations' path is specifically for local storage. Other valid protocols include s3://, gs://, azblob://, and mem://. Cloud credentials can be provided as environment variables through the "env" variable. | str | no |  |
+| max_size | Maximum allowed size for an individual attestation, in bytes. | str | no |  |
 
 #### Options for main > tas_single_node_ctlog
 

--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -238,7 +238,7 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 | private_keys | List of private keys for use within rekor. | list of dicts of 'private_keys' options | no |  |
 | public_keys | List of public keys for use within rekor. | list of dicts of 'public_keys' options | no |  |
 | sharding_config | Sharding configuration for rekor | list of dicts of 'sharding_config' options | no |  |
-| attestations | Configuration for Rekor attestation storage. | dict of 'attestations' options | no |  `{'enabled': True, 'url': 'file:///var/run/attestations?no_tmp_dir=true', 'max_size': '100000'}`  |
+| attestations | Configuration for Rekor attestation storage. | dict of 'attestations' options | no |  `{'enabled': True, 'url': 'file:///var/run/attestations?no_tmp_dir=true', 'max_size': 100000}`  |
 
 #### Options for main > tas_single_node_rekor > kms
 
@@ -282,7 +282,7 @@ Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_arti
 |---|---|---|---|---|
 | enabled | Enable Rekor attestation storage. | bool | no |  |
 | url | Url of the storage location, supports go-cloud blob URLs. The 'file:///var/run/attestations' path is specifically for local storage. Other valid protocols include s3://, gs://, azblob://, and mem://. Cloud credentials can be provided as environment variables through the "env" variable. | str | no |  |
-| max_size | Maximum allowed size for an individual attestation, in bytes. | str | no |  |
+| max_size | Maximum allowed size for an individual attestation, in bytes. | int | no |  |
 
 #### Options for main > tas_single_node_ctlog
 

--- a/roles/tas_single_node/meta/argument_specs.yml
+++ b/roles/tas_single_node/meta/argument_specs.yml
@@ -661,6 +661,34 @@ argument_specs:
                 version_added: "1.2.0"
             required: false
             version_added: "1.2.0"
+          attestations:
+            description: "Configuration for Rekor attestation storage."
+            type: "dict"
+            required: false
+            version_added: "1.3.0"
+            default:
+              enabled: true
+              url: "file:///var/run/attestations?no_tmp_dir=true"
+              max_size: "100000"
+            options:
+              enabled:
+                description: "Enable Rekor attestation storage."
+                type: "bool"
+                required: false
+                version_added: "1.3.0"
+              url:
+                description: |-
+                  Url of the storage location, supports go-cloud blob URLs. The 'file:///var/run/attestations'
+                  path is specifically for local storage. Other valid protocols include s3://, gs://, azblob://, and mem://.
+                  Cloud credentials can be provided as environment variables through the "env" variable.
+                type: "str"
+                required: false
+                version_added: "1.3.0"
+              max_size:
+                description: "Maximum allowed size for an individual attestation, in bytes."
+                type: "str"
+                required: false
+                version_added: "1.3.0"
       tas_single_node_setup_host_dns:
         description: "Set up DNS on the managed host to resolve URLs of the configured RHTAS services."
         type: "bool"

--- a/roles/tas_single_node/meta/argument_specs.yml
+++ b/roles/tas_single_node/meta/argument_specs.yml
@@ -669,7 +669,7 @@ argument_specs:
             default:
               enabled: true
               url: "file:///var/run/attestations?no_tmp_dir=true"
-              max_size: "100000"
+              max_size: 100000
             options:
               enabled:
                 description: "Enable Rekor attestation storage."
@@ -686,7 +686,7 @@ argument_specs:
                 version_added: "1.3.0"
               max_size:
                 description: "Maximum allowed size for an individual attestation, in bytes."
-                type: "str"
+                type: "int"
                 required: false
                 version_added: "1.3.0"
       tas_single_node_setup_host_dns:

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -37,8 +37,8 @@ spec:
                 key: ca-passphrase
                 name: rekor-secret
 {% for var in tas_single_node_rekor.env %}
-          - name: {{ var.name }}
-            value: {{ var.value }}
+          - name: "{{ var.name }}"
+            value: "{{ var.value }}"
 {% endfor %}
           readinessProbe:
             failureThreshold: 3

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -36,12 +36,10 @@ spec:
               secretKeyRef:
                 key: ca-passphrase
                 name: rekor-secret
-{% if tas_single_node_rekor.active_signer_type == 'kms' or tas_single_node_rekor.active_signer_type == 'tink'%}
 {% for var in tas_single_node_rekor.env %}
           - name: {{ var.name }}
             value: {{ var.value }}
 {% endfor %}
-{% endif %}
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -96,8 +94,11 @@ spec:
 {% else %}
                 --trillian_log_server.tlog_id={{ trillian_tree_id }} \
 {% endif %}
+{% if tas_single_node_rekor.attestations.enabled %}
                 --enable_attestation_storage \
-                --attestation_storage_bucket="file:///var/run/attestations?no_tmp_dir=true" \
+                --attestation_storage_bucket="{{ tas_single_node_rekor.attestations.url }}" \
+                --max_attestation_size="{{ tas_single_node_rekor.attestations.max_size }}" \
+{% endif %}
                 --port={{ tas_single_node_rekor_server_port_http }}
           image: "{{ tas_single_node_rekor_server_image }}"
           imagePullPolicy: IfNotPresent

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -20,11 +20,14 @@ _tas_single_node_rekor:
   active_tree_id: 0
   active_signer_type: file
   active_signer_id: "private-0"
-  env:
+  env: []
   private_keys: []
   public_keys: []
   sharding_config: []
-
+  attestations:
+    enabled: true
+    url: "file:///var/run/attestations?no_tmp_dir=true"
+    max_size: "100000"
 
 _tas_single_node_rekor_redis:
   database_deploy: true

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,8 +1,7 @@
+# cap ansible-core version at 2.19.0 until https://github.com/ansible/ansible-lint/pull/4683
+# is released otherwise ansible-lint fails
 ansible-core>=2.16.0,<2.19.0
 ansible-lint==25.1.2
-# cap ansible-core version until https://github.com/ansible/ansible-lint/pull/4683 is released
-# otherwise ansible-lint fails
-ansible-core<2.19
 antsibull-docs==2.19.1
 awscli==1.40.31
 botocore==1.38.32

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,5 +1,8 @@
 ansible-core>=2.16.0,<2.19.0
 ansible-lint==25.1.2
+# cap ansible-core version until https://github.com/ansible/ansible-lint/pull/4683 is released
+# otherwise ansible-lint fails
+ansible-core<2.19
 antsibull-docs==2.19.1
 awscli==1.40.31
 botocore==1.38.32


### PR DESCRIPTION
Implements configuration of settings related to Rekor attestation storage. I tested this both with the defaults - behavior stays the same as it is before this change - and with AWS S3. In both cases everything seems to be fine, I see no Rekor errors in logs and the attestation objects are correctly created in the storage and returned by the search UI.

## Summary by Sourcery

Add configurable Rekor attestation storage support to the TAS single-node role, allowing users to enable storage, set a custom backend URL, and enforce maximum attestation sizes.

New Features:
- Introduce an "attestations" configuration dict with options to enable storage, specify a storage URL, and set a maximum attestation size.

Enhancements:
- Pass attestation storage flags into the rekor-server startup template when enabled
- Provide default attestation storage settings in role variables

Documentation:
- Document the new "attestations" options in argument_specs and the role README