### PR TITLE
[SECURESIGN-2268] add rekor-monitor

### DIFF
--- a/molecule/default/vars/podman.yml
+++ b/molecule/default/vars/podman.yml
@@ -27,3 +27,5 @@ tas_single_node_podman:
       mirror: quay.io/securesign/trillian-createtree
     - location: registry.redhat.io/rhtas/client-server-rhel9
       mirror: quay.io/securesign/client-server
+    - location: registry.redhat.io/rhtas/rekor-monitor-rhel9
+      mirror: quay.io/securesign/rekor-monitor

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -24,6 +24,8 @@ tas_single_node_trillian_log_signer_image:
   "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:d489f3d9477ebe87a517ed552006dad835d0acead28f336ff0bbdd9708cd8ad6"
 tas_single_node_rekor_server_image:
   "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:055096ecfdd2a265a1e241b8632f3f8814cf348fcfb817d8a66de4d12c7ca9e6"
+tas_single_node_rekor_monitor_image:
+  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:20b18610b17f02194a8af9a7b55b87b65a860fd2ec4d9ad2715f1d5f1acdbf49"
 tas_single_node_ctlog_image:
   "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:65314f32eaf1c5414ca5d5c5e5188f10ecfb04e2c95eafdc73bb5a1d42c82efa"
 tas_single_node_rekor_redis_image:

--- a/roles/tas_single_node/tasks/podman.yml
+++ b/roles/tas_single_node/tasks/podman.yml
@@ -43,6 +43,7 @@
       "{{ tas_single_node_trillian_enabled }}",
       "{{ tas_single_node_trillian_enabled }}",
       "{{ tas_single_node_rekor_enabled }}",
+      "{{ tas_single_node_rekor_enabled and tas_single_node_rekor_monitor_enabled }}",
       "{{ tas_single_node_ctlog_enabled }}",
       "{{ tas_single_node_rekor_enabled and tas_single_node_rekor_redis.database_deploy }}",
       "{{ tas_single_node_rekor_enabled and tas_single_node_rekor_redis.database_deploy and tas_single_node_backfill_redis.enabled }}",
@@ -61,6 +62,7 @@
     - "{{ tas_single_node_trillian_log_server_image }}"
     - "{{ tas_single_node_trillian_log_signer_image }}"
     - "{{ tas_single_node_rekor_server_image }}"
+    - "{{ tas_single_node_rekor_monitor_image }}"
     - "{{ tas_single_node_ctlog_image }}"
     - "{{ tas_single_node_rekor_redis_image }}"
     - "{{ tas_single_node_backfill_redis_image }}"

--- a/roles/tas_single_node/tasks/podman/rekor.yml
+++ b/roles/tas_single_node/tasks/podman/rekor.yml
@@ -72,6 +72,15 @@
       secret: "{{ tas_single_node_rekor_secret }}"
       secret_changed: "{{ secret_result.changed }}"
 
+- name: Deploy Rekor Monitor Pod
+  ansible.builtin.include_tasks: podman/install_manifest.yml
+  vars:
+    podman_spec:
+      state: started
+      systemd_file: rekor_monitor
+      network: "{{ tas_single_node_podman_network }}"
+      kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/rekor/rekor-monitor.j2') | from_yaml }}"
+
 - name: Deploy backfill Redis job
   ansible.builtin.include_tasks: podman/install_manifest.yml
   vars:

--- a/roles/tas_single_node/tasks/volumes.yml
+++ b/roles/tas_single_node/tasks/volumes.yml
@@ -9,7 +9,8 @@
         [
           "rekor-server",
           tas_single_node_tuf_repository_volume_name,
-          tas_single_node_tuf_signing_keys_volume_name
+          tas_single_node_tuf_signing_keys_volume_name,
+          "rekor-monitor-storage"
         ]
       }}
 

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-monitor.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-monitor.j2
@@ -59,6 +59,26 @@ spec:
             - containerPort: {{ tas_single_node_rekor_monitor_port_http }}
               protocol: TCP
           resources: {}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - grep -q rekor_monitor /proc/*/comm
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - test -f /data/checkpoint_log.txt
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 5
           volumeMounts:
             - mountPath: /data
               name: rekor-monitor-storage

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-monitor.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-monitor.j2
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ tas_single_node_rekor_monitor_pod }}"
+  namespace: rekor-system
+  labels:
+    app.podman.io/component: rekor-monitor
+    app.podman.io/part-of: trusted-artifact-signer
+    app.name: rekor-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.name: rekor-monitor
+  template:
+    metadata:
+      labels:
+        app.podman.io/component: rekor-monitor
+        app.podman.io/part-of: trusted-artifact-signer
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9464"
+        prometheus.io/scrape: "true"
+    spec:
+      initContainers:
+        - name: wait-for-rekor-server
+          image: "{{ tas_single_node_rekor_monitor_image }}"
+          command:
+            - /bin/sh
+            - -c
+            - until curl -sf http://{{ tas_single_node_rekor_server_pod }}-pod:{{ tas_single_node_rekor_server_port_http }} > /dev/null 2>&1; do echo 'Waiting
+              for rekor-server to be ready...'; sleep 5; done
+      containers:
+        - name: rekor-monitor
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - exec /rekor_monitor --file=/data/checkpoint_log.txt --once=false --interval={{ tas_single_node_rekor.monitor.interval }} --url=http://{{ tas_single_node_rekor_server_pod }}-pod:{{ tas_single_node_rekor_server_port_http }}
+          image: "{{ tas_single_node_rekor_monitor_image }}"
+          imagePullPolicy: IfNotPresent
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: file
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65533
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: {{ tas_single_node_rekor_monitor_port_http }}
+              protocol: TCP
+          resources: {}
+          volumeMounts:
+            - mountPath: /data
+              name: rekor-monitor-storage
+      restartPolicy: Always
+      volumes:
+        - name: rekor-monitor-storage
+          persistentVolumeClaim:
+            claimName: rekor-monitor-storage          

--- a/roles/tas_single_node/templates/manifests/rekor/rekor-monitor.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-monitor.j2
@@ -28,8 +28,18 @@ spec:
           command:
             - /bin/sh
             - -c
-            - until curl -sf http://{{ tas_single_node_rekor_server_pod }}-pod:{{ tas_single_node_rekor_server_port_http }} > /dev/null 2>&1; do echo 'Waiting
-              for rekor-server to be ready...'; sleep 5; done
+            - |
+              max_retries=60
+              count=0
+              until curl -sf http://{{ tas_single_node_rekor_server_pod }}-pod:{{ tas_single_node_rekor_server_port_http }} > /dev/null 2>&1; do
+                count=$((count+1))
+                if [ "$count" -ge "$max_retries" ]; then
+                  echo "Timed out waiting for rekor-server after $max_retries attempts."
+                  exit 1
+                fi
+                echo 'Waiting for rekor-server to be ready...'
+                sleep 5
+              done
       containers:
         - name: rekor-monitor
           command:

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -28,6 +28,8 @@ _tas_single_node_rekor:
     enabled: true
     url: "file:///var/run/attestations?no_tmp_dir=true"
     max_size: "100000"
+  monitor:
+    interval: 10m
 
 _tas_single_node_rekor_redis:
   database_deploy: true
@@ -140,6 +142,7 @@ tas_single_node_rekor_templates:
 # Individual service enablement
 tas_single_node_trillian_enabled: true
 tas_single_node_rekor_enabled: true
+tas_single_node_rekor_monitor_enabled: true
 tas_single_node_ctlog_enabled: true
 tas_single_node_tuf_enabled: true
 tas_single_node_tsa_enabled: true
@@ -258,6 +261,9 @@ tas_single_node_rekor_server_port_metrics: 2112
 
 tas_single_node_rekor_search_ui_pod: rekor-search-ui
 tas_single_node_rekor_search_ui_port_tcp: 3000
+
+tas_single_node_rekor_monitor_pod: rekor-monitor
+tas_single_node_rekor_monitor_port_http: 9464
 
 tas_single_node_trillian_logserver_pod: trillian-logserver
 tas_single_node_trillian_logserver_port_rpc: 8091


### PR DESCRIPTION
## Summary by Sourcery

Integrate Rekor Monitor into the TAS single-node deployment by adding configuration variables, container image defaults, podman tasks, volume mounts, and a Kubernetes manifest template to deploy and manage the monitoring service.

New Features:
- Introduce a new enablement flag and interval configuration for the Rekor Monitor service
- Add default Rekor Monitor container image and pod name/port variables
- Deploy the Rekor Monitor pod via Podman with a systemd unit and templated Kubernetes manifest

Enhancements:
- Add a persistent storage volume for Rekor Monitor data