### PR TITLE
[SECURESIGN-2191] Set max log entry size in Trillian

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -19,9 +19,9 @@ tas_single_node_trust_root:
 tas_single_node_fulcio_server_image:
   "registry.redhat.io/rhtas/fulcio-rhel9@sha256:995173a0ed708a13806d5bb89cecc085aec407468236059701db71273c614361"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:09be7a6a3e76a222f592a7f4a26932db2051fa92c3c08241aa57a044c54da6f8"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:12d038266092d08107531cc122807b796fad1d46fb23a76d05d7fe6b8f24ac4c"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:e1bbb9d63d84d26917cc4259baa14ca325481cc6dba8fcc4d5a805381b43129a"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:dae027ed9eb864a1abeab7e2b200ba682dd639288d877f9d1993631d4d7504f3"
 tas_single_node_rekor_server_image:
   "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:d548a7ac3828b0abe31fa7f37b50c61272a979874f30c260629c5e53e617c12c"
 tas_single_node_rekor_monitor_image:

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logserver.j2
@@ -43,6 +43,7 @@ spec:
                 --mysql_uri="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOSTNAME}:${MYSQL_PORT})/${MYSQL_DATABASE}" \
                 --rpc_endpoint=0.0.0.0:{{ tas_single_node_trillian_logserver_port_rpc }} \
                 --http_endpoint=0.0.0.0:{{ tas_single_node_trillian_logserver_port_metrics }} \
+                --max_msg_size_bytes={{ tas_single_node_trillian.max_msg_size_bytes }} \
                 --alsologtostderr{% if tas_single_node_trillian.trusted_ca != "" and not tas_single_node_trillian.database_deploy %} \
                 --mysql_tls_ca=/var/run/configs/tas/ca-trust/trillian-trusted-ca.pem \
                 --mysql_server_name="${MYSQL_HOSTNAME}"{% endif %}

--- a/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.j2
+++ b/roles/tas_single_node/templates/manifests/trillian/trillian-logsigner.j2
@@ -59,6 +59,7 @@ spec:
                 --mysql_uri="${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOSTNAME}:${MYSQL_PORT})/${MYSQL_DATABASE}" \
                 --rpc_endpoint=0.0.0.0:{{ tas_single_node_trillian_logsigner_port_rpc }} \
                 --http_endpoint=0.0.0.0:{{ tas_single_node_trillian_logsigner_port_metrics }} \
+                --max_msg_size_bytes={{ tas_single_node_trillian.max_msg_size_bytes }} \
                 --force_master=true \
                 --alsologtostderr{% if tas_single_node_trillian.trusted_ca != "" and not tas_single_node_trillian.database_deploy %} \
                 --mysql_tls_ca=/var/run/configs/tas/ca-trust/trillian-trusted-ca.pem \

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -52,6 +52,7 @@ _tas_single_node_trillian:
     host: trillian-mysql-pod
     port: 3306
   trusted_ca: ""
+  max_msg_size_bytes: 153600
 
 _tas_single_node_ingress_certificates:
   root:


### PR DESCRIPTION
## Summary by Sourcery

Enable configuration of maximum gRPC message size for Trillian components and refresh their container images to the latest versions.

Enhancements:
- Update Trillian logserver and signer container images to new digests
- Introduce configurable max_msg_size_bytes variable with a default value
- Add --max_msg_size_bytes flag to Trillian logserver and logsigner startup commands