### PR TITLE
:robot: [RHTAS-build-bot] [main] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -17,25 +17,25 @@ tas_single_node_trust_root:
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:6e3d381081447207d965319628b7c434138d1c182ee997ad9a66479f6dec677e"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:6270ba29adf779de5d3916d5e82f1cd9491ba89d4ae2042347b6ad6d1819dd26"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:0bc67c883fce1b5f0e46d66f8a952b7015527c98169a50e8bd59dc0e02b02528"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:12b438ea70f83ee6edb12c96b507f92510f4afba824eac34c8f50793c4199db6"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:e5c4d087167434502b2a1fef5545700e072db799219cf125e023ba1f44c00da2"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:1d782a127d2f8bdab633f287cb2df2e400ae91bf5d4b913473539d8512dfaab6"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:04707b956d0223a9b22dbd78d61f775f714e47482124174a53f573b47cbc1c9d"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:02fbd4772c185edf38fcee4e5c5e1c9dad82b77c9da824addaebc445b67d35ac"
 tas_single_node_rekor_monitor_image:
   "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:20b18610b17f02194a8af9a7b55b87b65a860fd2ec4d9ad2715f1d5f1acdbf49"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:c3f4716c248f25d1375bd57d2955773b7a118b9b821b818ca143348e80b80f44"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:eb38e98dbb9828fe033a5388609132f7246fe77d2f4d258d015a94ea30752b24"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:3430ddebd5864cafdf88e0f4ec36745db1c8020e0f124c0717146d423419a019"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:fc018a45b7eb48690c46c83f52cac55fa40089e6b02686bc21265dc7c2205b8f"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:0ad7a5bfd390d603c4a63ba84f754aff9e154b4b7887c990f2658f3a006a026a"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:09b4aeeb607c88c72f69e6f87cb840c82ef5752c64a58fa13551db749fac2530"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:d6385c3a70b804a125cd2a1872e46024f3ea206c29ebb91bc4de7b05cc455522"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:640633823a54c11fe2a8b3d05e571399fda415b6f0b3adf1ba9806882a94bdd4"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:badf7930dc71419f20b3da891624329f41f048d17c91b6ca21d836b6d8f74a6a"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:a93df3206409de75613d398e7dcd8b30ff7cc36eb00349c435784f73f00a2335"
 tas_single_node_http_server_image:
   "registry.redhat.io/ubi9/httpd-24@sha256:badeee0aa3477e61de64f6a2b93e8a3673edd38fc860125f7536506f3d592132"
 tas_single_node_trillian_netcat_image:
@@ -43,15 +43,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:e63a4bef4b5c876b034b8dfe80fe24afd1164ff59e802f3b5dead799ab6f504c"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:6b03e69186f7be2b9a789289cbc071e24864dfa115792d3450b94f774e12e706"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:531603563c69aac6905cd6b8157d30781040527404ac2313acba5a9310e0b713"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:3348c94e6dee74e4ccb446bcd71b1c23009942fdc6abb4f2c28964a0fca72352"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:fe31830df2d99359749cb86cd1ac2f32fcc3de07aae427d2f2cd3998d31d2833"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:929f4d6ab482788c6808f790675602aa6598166dbb00be7139f42300738b3c2e"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:812315ab0ef006799ebe158dff67773b56d5d5e86d07dee9341214d1b49f4542"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:1698853a7e742b141dea2e052d72d4e1ba5a2ca1de2ef51909f3acfbc5dd1fe9"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:1c2201d50469d70ec6e21546c7c74bd52251d420dc1dcfa5375c1cf61dd3a9fd"
 
 tas_single_node_podman: {}
 


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `3348c94` | `fe31830` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `6e3d381` | `6270ba2` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `c3f4716` | `eb38e98` |
| registry.redhat.io/rhtas/createtree-rhel9 | `929f4d6` | `812315a` |
| registry.redhat.io/rhtas/client-server-rhel9 | `1698853` | `1c2201d` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `6b03e69` | `5316035` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `04707b9` | `02fbd47` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `0bc67c8` | `12b438e` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `d6385c3` | `6406338` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `0ad7a5b` | `09b4aee` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `e5c4d08` | `1d782a1` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `badf793` | `a93df32` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `3430dde` | `fc018a4` |
---