### PR TITLE
[SECURESIGN-2189] Set request size limits in Rekor

### DIFF
--- a/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
+++ b/roles/tas_single_node/templates/manifests/rekor/rekor-server.j2
@@ -99,6 +99,7 @@ spec:
                 --attestation_storage_bucket="{{ tas_single_node_rekor.attestations.url }}" \
                 --max_attestation_size="{{ tas_single_node_rekor.attestations.max_size }}" \
 {% endif %}
+                --max_request_body_size={{ tas_single_node_rekor.max_request_body_size }} \
                 --port={{ tas_single_node_rekor_server_port_http }}
           image: "{{ tas_single_node_rekor_server_image }}"
           imagePullPolicy: IfNotPresent

--- a/roles/tas_single_node/vars/main.yml
+++ b/roles/tas_single_node/vars/main.yml
@@ -30,6 +30,7 @@ _tas_single_node_rekor:
     max_size: "100000"
   monitor:
     interval: 10m
+  max_request_body_size: 10485760
 
 _tas_single_node_rekor_redis:
   database_deploy: true

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,10 +1,10 @@
 # cap ansible-core version at 2.19.0 until https://github.com/ansible/ansible-lint/pull/4683
 # is released otherwise ansible-lint fails
 ansible-core>=2.16.0,<2.19.0
-ansible-lint==25.1.2
+ansible-lint==25.6.1
 antsibull-docs==2.19.1
-awscli==1.40.31
-botocore==1.38.32
-boto3==1.38.32
+awscli==1.41.9
+botocore==1.39.15
+boto3==1.39.9
 galaxy-importer==0.4.30
-molecule==25.1.0
+molecule==25.6.0

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -4,7 +4,7 @@ ansible-core>=2.16.0,<2.19.0
 ansible-lint==25.6.1
 antsibull-docs==2.19.1
 awscli==1.41.9
-botocore==1.39.15
+botocore==1.39.9
 boto3==1.39.9
 galaxy-importer==0.4.30
 molecule==25.6.0

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -7,4 +7,4 @@ awscli==1.41.9
 botocore==1.39.9
 boto3==1.39.9
 galaxy-importer==0.4.30
-molecule==25.6.0
+molecule==25.1.0

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,7 +1,7 @@
 # cap ansible-core version at 2.19.0 until https://github.com/ansible/ansible-lint/pull/4683
 # is released otherwise ansible-lint fails
 ansible-core>=2.16.0,<2.19.0
-ansible-lint==25.6.1
+ansible-lint==25.1.2
 antsibull-docs==2.19.1
 awscli==1.41.9
 botocore==1.39.9


### PR DESCRIPTION
## Summary by Sourcery

Enable configuring request size limits for the Rekor server by introducing a max_request_body_size variable and updating the server manifest to include the corresponding flag

New Features:
- Add max_request_body_size variable with default 10485760
- Support passing max_request_body_size to the Rekor server via CLI flag

Deployment:
- Update Rekor server Kubernetes manifest to include --max_request_body_size flag