### PR TITLE
:robot: [RHTAS-build-bot] [main] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -17,25 +17,25 @@ tas_single_node_trust_root:
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:6270ba29adf779de5d3916d5e82f1cd9491ba89d4ae2042347b6ad6d1819dd26"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:1a1c925abbfea3a2bb7a8bd955e3b59e4f57b57a206249ec9387bd991ddd4930"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:12b438ea70f83ee6edb12c96b507f92510f4afba824eac34c8f50793c4199db6"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:f78ba184066c00be31d56d1e73e179c5b2b98ca1f5693f4012235700c214fb47"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:1d782a127d2f8bdab633f287cb2df2e400ae91bf5d4b913473539d8512dfaab6"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:f9348964905488487d9d190b948333f98c701badcd93ef756c3a48d369cb0c09"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:02fbd4772c185edf38fcee4e5c5e1c9dad82b77c9da824addaebc445b67d35ac"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:c379e35cc91dafd51222526be20d647dde63ea11e33d21a3d63423d3cae7f027"
 tas_single_node_rekor_monitor_image:
   "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:20b18610b17f02194a8af9a7b55b87b65a860fd2ec4d9ad2715f1d5f1acdbf49"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:eb38e98dbb9828fe033a5388609132f7246fe77d2f4d258d015a94ea30752b24"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:d170f38476e9f7119feee0af316b44066b42ed34a70e61374a02bd596e4ea603"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:fc018a45b7eb48690c46c83f52cac55fa40089e6b02686bc21265dc7c2205b8f"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:9330bd1929c7ad760b2778a7027b2c23e57a6ca7d141459647812f724ee761b7"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:09b4aeeb607c88c72f69e6f87cb840c82ef5752c64a58fa13551db749fac2530"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:2af17924abe44c1a04c7436d3cde738593f133674a1a9aa9c6bc0f4f1a942453"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:640633823a54c11fe2a8b3d05e571399fda415b6f0b3adf1ba9806882a94bdd4"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:63db2bb4d521963c7b4a61e50eea2d19fc7b03f80b87326d07dcbf8f2d7e3940"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:a93df3206409de75613d398e7dcd8b30ff7cc36eb00349c435784f73f00a2335"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:9291e04bd57c1f0ec60a3f02d7d6b955ce4c8865858fa411b7058ad6b50f5a5e"
 tas_single_node_http_server_image:
   "registry.redhat.io/ubi9/httpd-24@sha256:badeee0aa3477e61de64f6a2b93e8a3673edd38fc860125f7536506f3d592132"
 tas_single_node_trillian_netcat_image:
@@ -43,15 +43,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:e63a4bef4b5c876b034b8dfe80fe24afd1164ff59e802f3b5dead799ab6f504c"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:531603563c69aac6905cd6b8157d30781040527404ac2313acba5a9310e0b713"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:0c0e303488f19b69f7dca2ee32cc7b19077a6f144509c8b6f353dd2561ee89cd"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:fe31830df2d99359749cb86cd1ac2f32fcc3de07aae427d2f2cd3998d31d2833"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:4b0a30f89a249cfedbd7e7326f4511b6c3f30d44907489cd2349a865922479df"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:812315ab0ef006799ebe158dff67773b56d5d5e86d07dee9341214d1b49f4542"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:c5490942fa6e651c2412ebacf40cc522c5b90be5da61e790e9312ae6cbd8b1b7"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:1c2201d50469d70ec6e21546c7c74bd52251d420dc1dcfa5375c1cf61dd3a9fd"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:e65e603e56b0565b5c5e9c174f94812599b49e4c8134f4d7cdbe00bd18158221"
 
 tas_single_node_podman: {}
 


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `fe31830` | `4b0a30f` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `6270ba2` | `1a1c925` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `eb38e98` | `d170f38` |
| registry.redhat.io/rhtas/createtree-rhel9 | `812315a` | `c549094` |
| registry.redhat.io/rhtas/client-server-rhel9 | `1c2201d` | `e65e603` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `5316035` | `0c0e303` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `02fbd47` | `c379e35` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `12b438e` | `f78ba18` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `6406338` | `63db2bb` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `09b4aee` | `2af1792` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `1d782a1` | `f934896` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `a93df32` | `9291e04` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `fc018a4` | `9330bd1` |
---