### PR TITLE
fix: cherry pick aap-test updates from main

### DIFF
--- a/molecule/aap-test/converge.yml
+++ b/molecule/aap-test/converge.yml
@@ -22,15 +22,15 @@
 
     aap_setup_prep_inv_nodes:
       automationcontroller:
-        127.0.0.1:
+        - "127.0.0.1"
       automationhub:
-        127.0.0.1:
+        - "127.0.0.1"
       database:
-        127.0.0.1:
+        - "127.0.0.1"
       automationgateway:
-        127.0.0.1:
+        - "127.0.0.1"
       automationeda:
-        127.0.0.1:
+        - "127.0.0.1"
     aap_setup_prep_inv_vars:
       all:
         ansible_user: "ec2-user"

--- a/molecule/aap-test/converge.yml
+++ b/molecule/aap-test/converge.yml
@@ -164,8 +164,7 @@
       delegate_to: localhost
       block:
         - name: Include role to add subscription to controller
-          ansible.builtin.include_role:
-            name: infra.aap_configuration.controller_license
+          ansible.builtin.include_tasks: files/subscription.yml
           vars:
             controller_dependency_check: true
             aap_hostname: "{{ aap_instance_ip }}"
@@ -177,7 +176,9 @@
             aap_request_timeout: 900
             controller_license:
               use_lookup: true
-              force: true
+              filters:
+                product_name: "Red Hat Ansible Automation Platform"
+                support_level: "Self-Support"
 
     - name: Create project for TAS single node playbook
       delegate_to: localhost

--- a/molecule/aap-test/files/subscription.yml
+++ b/molecule/aap-test/files/subscription.yml
@@ -1,0 +1,34 @@
+---
+
+- name: subscription | Get subscriptions with a filter
+  ansible.controller.subscriptions:
+    client_id: "{{ redhat_subscription_username }}"
+    client_secret: "{{ redhat_subscription_password }}"
+    filters: "{{ controller_license.filters }}"
+    # Role Standard Options
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  register: subscription
+  when:
+    - "'use_lookup' in controller_license"
+    - controller_license.use_lookup
+
+- name: subscription | Install the Controller license
+  ansible.controller.license:
+    subscription_id: "{{ controller_license.pool_id | default(subscription.subscriptions[(controller_license.list_num | default(0))].subscription_id) }}"
+    force: "{{ controller_license.force | default(omit) }}"
+    state: "{{ controller_license.state | default(omit) }}"
+
+    # Role Standard Options
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  when: controller_license is defined
+...

--- a/molecule/aap-test/requirements.yml
+++ b/molecule/aap-test/requirements.yml
@@ -3,11 +3,12 @@
 ---
 
 collections:
-  - community.crypto
-  - containers.podman
-  - amazon.aws
-  - ansible.controller
-  - ansible.platform
-  - infra.aap_utilities
-  - infra.ah_configuration
-  - infra.aap_configuration
+  - name: community.crypto
+  - name: containers.podman
+  - name: amazon.aws
+  - name: ansible.controller
+  - name: ansible.platform
+  - name: infra.aap_utilities
+    version: 2.6.1
+  - name: infra.ah_configuration
+  - name: infra.aap_configuration

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,3 +1,4 @@
+ansible-core>=2.16.0,<2.19.0
 ansible-lint==25.1.2
 antsibull-docs==2.16.3
 awscli==1.38.9


### PR DESCRIPTION
**AAP test build**: https://github.com/securesign/artifact-signer-ansible/actions/runs/17098168739/job/48487501558

## Summary by Sourcery

Apply aap-test updates by fixing inventory host format, overhauling subscription license handling, and updating collection requirements.

Enhancements:
- Convert inventory host definitions to list format in molecule/aap-test/converge.yml
- Replace include_role with include_tasks and add subscription.yml to manage controller subscriptions and license installation
- Add ci_issuer_metadata field to tas single node test variables

Build:
- Specify collection entries by name and pin infra.aap_utilities to version 2.6.1 in molecule/aap-test/requirements.yml

Tests:
- Introduce molecule/aap-test/files/subscription.yml with tasks to fetch and install controller subscriptions via ansible.controller modules