### PR TITLE
:robot: [RHTAS-build-bot] [main] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -17,25 +17,25 @@ tas_single_node_trust_root:
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:1d4bca15d3d4ebd9b8322c543346e31bbbad61d714f8d53046714ab0606a8347"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:5e6b0e93b1042c56583bc76184eac36256d8dea145450a0720c5b2bb691674a5"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:138f8a66f5aac42a172cc1ab5029c20fac7c79951fbec8a894051642196e6161"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:d1e1dd2742559a6e79bb41a56614936837694aea87bcfb4817fe78bb114e56f5"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:c16d3b3ca6666bfac4d429a0d357ed42acc575c227f4fc693a5d4decc60222bc"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:c7b8040d505f87b178ad09047eb86454abfc3b2e32b11b25ef41c83a2da06ee5"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:b616397d308c3acbaba0258fb9fd01689a12d8a18b73b305d3711450b7124627"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:9866be40e524399007996ba24ce7c5e35bf92d8e8a0962a7e1a5120507cc1715"
 tas_single_node_rekor_monitor_image:
   "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:e908fbad531780bb9356cb3bc1ca11d4e6c92096c745bcb247674ebdf2171fec"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:990005f9e5ea71127ea114dc440ea9e427d7c9bda034af856a601834ea831a17"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:c7f5f5966bab2279091a19ce5218cb2b61ea0ee60d5124abdf107df4d46d294e"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:122f0b81936787e3b882bcdc0b86bcefd72b4705bc0d1ca0cae352c55662273f"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:85bc76555a5f7d1dacd6450b44e16547c03e5eb9c3aff25f163d3403f4835e40"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:573e856779b3d44ab41f1a2872d086a69f09854e307bf05f6d9b4a1202697830"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:782c7a3084afb30d963fe6b520e3d6d1ae6118d43a0940017d6454cd288e1d68"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:ce5b8b95a8be681c77b3e27e68439c7342c74021cb95bb1056b57c8c520235b6"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:5121a435d9c0e6c9a59f6cb220b33f174516f8a29b8ba6e403c59a9d03ad499e"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:927d7aa712a44cfdf288acbb8c9e52e3eec3f694ec97a68078a5ddec2e8aae14"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:782eed361fc11344e2924245acdaabe3ccf20ca7f21a323313c697ea54296a92"
 tas_single_node_http_server_image:
   "registry.redhat.io/ubi9/httpd-24@sha256:29382518403a4361c48fccc057163dc4a9f43ee159432754fa63c76485b223f5"
 tas_single_node_trillian_netcat_image:
@@ -43,15 +43,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:126903359331eb9f2c87950f952442db456750190956b9301d00acfcadbc19ed"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:d08dadc4955ecd969e4d087fa07ed6a22b6a333fcc76f69bff20e3d69069879f"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:a04d1a180f759844f5d0b4836d0167a34c8cb07b1d49156585ba9b5e5c96aed2"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:b13afb5d29a12e3bede2bcece9cdbad857e2eca104df953d27ab0ccc7d2f158c"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:b51f26c1a69a4911a6c2850d558969ae47b3884dc2fc99833fd98bce33121e56"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:582e17ad58afabc7683b6d805c9207ecbfd3a4a73956e81e5691d65c089ee0c6"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:e6aa62dc213e74c457408922f9415c72533798b697c6272e0505d24dbe066f9e"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:a4b821d3e8b5f7a461e1c4486181cd78ffb323006af4c1c78d32347379d8ddcf"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:a701971d80e2ad3753b77b90530aa6e38fc3602da460110d8685a03643a76480"
 
 tas_single_node_podman: {}
 

--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -25,7 +25,7 @@ tas_single_node_trillian_log_signer_image:
 tas_single_node_rekor_server_image:
   "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:9866be40e524399007996ba24ce7c5e35bf92d8e8a0962a7e1a5120507cc1715"
 tas_single_node_rekor_monitor_image:
-  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:e908fbad531780bb9356cb3bc1ca11d4e6c92096c745bcb247674ebdf2171fec"
+  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:1d30a291ddf3d5ae215e24cc81c608b80d686338615ac4f3fc23503381936265"
 tas_single_node_ctlog_image:
   "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:c7f5f5966bab2279091a19ce5218cb2b61ea0ee60d5124abdf107df4d46d294e"
 tas_single_node_rekor_redis_image:


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `b13afb5` | `b51f26c` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `1d4bca1` | `5e6b0e9` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `990005f` | `c7f5f59` |
| registry.redhat.io/rhtas/createtree-rhel9 | `582e17a` | `e6aa62d` |
| registry.redhat.io/rhtas/client-server-rhel9 | `a4b821d` | `a701971` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `d08dadc` | `a04d1a1` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `b616397` | `9866be4` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `138f8a6` | `d1e1dd2` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `ce5b8b9` | `5121a43` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `573e856` | `782c7a3` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `c16d3b3` | `c7b8040` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `927d7aa` | `782eed3` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `122f0b8` | `85bc765` |
---