### PR TITLE
:robot: [RHTAS-build-bot] [main] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -25,7 +25,7 @@ tas_single_node_trillian_log_signer_image:
 tas_single_node_rekor_server_image:
   "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:abaa247777eb05bf8c97ba1ffc30c00d0d84590fac2fdfbffa06ba374b924888"
 tas_single_node_rekor_monitor_image:
-  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:1d30a291ddf3d5ae215e24cc81c608b80d686338615ac4f3fc23503381936265"
+  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:da3aa5c441653f00c4b558ef6ebf21fef518731e70f152a1fd3a750b1145d901"
 tas_single_node_ctlog_image:
   "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:08302a0af012c1a1f04ef15de86558c9eef55620ab7b179fbda170025f0584be"
 tas_single_node_rekor_redis_image:


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `b51f26c` | `eaae082` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `5e6b0e9` | `043103f` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `c7f5f59` | `08302a0` |
| registry.redhat.io/rhtas/createtree-rhel9 | `e6aa62d` | `2447587` |
| registry.redhat.io/rhtas/client-server-rhel9 | `a701971` | `e946126` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `e7d0f93` | `8f8a5d4` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `9866be4` | `abaa247` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `d1e1dd2` | `2dd6967` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `5121a43` | `2d91dce` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `782c7a3` | `b311fb8` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `c7b8040` | `110509f` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `782eed3` | `978f438` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `85bc765` | `e7f5a9a` |
---