### PR TITLE
chore: Add debug info

### DIFF
--- a/molecule/upgrade/prepare.yml
+++ b/molecule/upgrade/prepare.yml
@@ -15,9 +15,45 @@
     - name: Configure Dex OIDC instance
       ansible.builtin.include_tasks: ../common/dex-setup.yaml
 
+    - name: Display installed collection version
+      ansible.builtin.debug:
+        msg: >
+          The 'redhat.artifact_signer' collection version being used is: 
+          {{ lookup('community.general.collection_version', 'redhat.artifact_signer') }}
+
     - name: Apply latest release role
       ansible.builtin.include_role:
         name: redhat.artifact_signer.tas_single_node
+
+    - name: Collect image SHAs
+      block:
+        - name: Get pod information for multiple pods
+          containers.podman.podman_pod_info:
+            name: "{{ item.name }}"
+          register: pod_info_list
+          loop: "{{ tas_pods }}"
+        - name: Get container information for all containers in the pods
+          containers.podman.podman_container_info:
+            name: "{{ container_ids }}"
+          vars:
+            container_ids: "{{ item.pods[0].Containers | map(attribute='Id') | list }}"
+          loop: "{{ pod_info_list.results }}"
+          loop_control:
+            label: "{{ item.pods[0].Name }}"
+          when: item.pods is defined and item.pods[0].Containers is defined
+          register: container_info_list
+        - name: Create a dictionary of pod names and container images
+          set_fact:
+            pod_images: "{{ pod_images | default({}) | combine({ pod_info_list.results[index].pods[0].Name: item.containers | map(attribute='ImageDigest') | list }) }}"
+          loop: "{{ container_info_list.results }}"
+          loop_control:
+            index_var: index
+        - name: Save released pod_images (Image SHAs) for verification
+          ansible.builtin.copy:
+            content: "{{ {'released_images' : pod_images} | to_nice_yaml }}"
+            dest: "{{ molecule_ephemeral_directory }}/images.yml"
+          delegate_to: localhost
+          become: false
 
     - name: Prepare signed data to be verified after upgrade
       ansible.builtin.include_tasks:

--- a/molecule/upgrade/vars/vars.yml
+++ b/molecule/upgrade/vars/vars.yml
@@ -1,1 +1,40 @@
-../../default/vars/vars.yml
+tas_single_node_fulcio:
+  fulcio_config:
+    oidc_issuers:
+      - issuer: "http://dex-idp:5556/dex"
+        url: "http://dex-idp:5556/dex"
+        client_id: trusted-artifact-signer
+        type: email
+      - issuer: "sigstore"
+        url: "https://oauth2.sigstore.dev/auth"
+        client_id: sigstore
+        type: email
+tas_single_node_base_hostname: myrhtas
+tas_single_node_cockpit:
+  enabled: false
+tas_single_node_registry_username: "{{ lookup('env', 'TAS_SINGLE_NODE_REGISTRY_USERNAME') }}"
+tas_single_node_registry_password: "{{ lookup('env', 'TAS_SINGLE_NODE_REGISTRY_PASSWORD') }}"
+
+tas_pods:
+  - name: cli-server-pod
+    image_var: tas_single_node_client_server_image
+  - name: ctlog-pod
+    image_var: tas_single_node_ctlog_image
+  - name: fulcio-server-pod
+    image_var: tas_single_node_fulcio_server_image
+  - name: rekor-redis-pod
+    image_var: tas_single_node_rekor_redis_image
+  - name: rekor-server-pod
+    image_var: tas_single_node_rekor_server_image
+  - name: rekor-search-ui-pod
+    image_var: tas_single_node_rekor_search_ui_image
+  - name: trillian-logserver-pod
+    image_var: tas_single_node_trillian_log_server_image
+  - name: trillian-logsigner-pod
+    image_var: tas_single_node_trillian_log_signer_image
+  - name: trillian-mysql-pod
+    image_var: tas_single_node_trillian_db_image
+  - name: tsa-server-pod
+    image_var: tas_single_node_timestamp_authority_image
+  - name: tuf-init-pod
+    image_var: tas_single_node_tuf_image

--- a/molecule/upgrade/verify.yml
+++ b/molecule/upgrade/verify.yml
@@ -4,31 +4,9 @@
   become: true
   vars:
     test_dir_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/../test"
-    tas_pods:
-      - name: cli-server-pod
-        image_var: tas_single_node_client_server_image
-      - name: ctlog-pod
-        image_var: tas_single_node_ctlog_image
-      - name: fulcio-server-pod
-        image_var: tas_single_node_fulcio_server_image
-      - name: rekor-redis-pod
-        image_var: tas_single_node_rekor_redis_image
-      - name: rekor-server-pod
-        image_var: tas_single_node_rekor_server_image
-      - name: rekor-search-ui-pod
-        image_var: tas_single_node_rekor_search_ui_image
-      - name: trillian-logserver-pod
-        image_var: tas_single_node_trillian_log_server_image
-      - name: trillian-logsigner-pod
-        image_var: tas_single_node_trillian_log_signer_image
-      - name: trillian-mysql-pod
-        image_var: tas_single_node_trillian_db_image
-      - name: tsa-server-pod
-        image_var: tas_single_node_timestamp_authority_image
-      - name: tuf-init-pod
-        image_var: tas_single_node_tuf_image
   vars_files:
     - vars/vars.yml
+    - "{{ molecule_ephemeral_directory }}/images.yml"
   tasks:
     - name: Load development build vars
       include_vars:
@@ -63,6 +41,7 @@
       assert:
         that:
           - digest in pod_images[item.name]
+          - digest not in released_images[item.name]
       vars:
         digest: "{{ dev_vars[item.image_var].split('@')[1] }}"
       loop: "{{ tas_pods }}"


### PR DESCRIPTION
## Summary by Sourcery

Add debug output and capture image SHAs in the upgrade scenario, externalize pod list into a vars file, and enhance verification to ensure new images differ from released ones

Enhancements:
- Display the `redhat.artifact_signer` Ansible collection version in the prepare playbook
- Collect pod container image SHAs before upgrade and write them to `images.yml` for later verification
- Move `tas_pods` definitions into a dedicated variables file under `molecule/upgrade/vars/vars.yml`
- Load the captured `released_images` in the verify playbook and assert that upgraded image digests differ from the released ones