### PR TITLE
fix: fix app & component labels

### DIFF
--- a/.tekton/artifact-signer-ansible-pull-request.yaml
+++ b/.tekton/artifact-signer-ansible-pull-request.yaml
@@ -14,8 +14,8 @@ metadata:
       || "requirements.json".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: ansible
-    appstudio.openshift.io/component: artifact-signer-ansible
+    appstudio.openshift.io/application: ansible-v1-3
+    appstudio.openshift.io/component: artifact-signer-ansible-v1-3
     pipelines.appstudio.openshift.io/type: build
   name: artifact-signer-ansible-on-pull-request
   namespace: rhtas-tenant

--- a/.tekton/artifact-signer-ansible-push.yaml
+++ b/.tekton/artifact-signer-ansible-push.yaml
@@ -13,8 +13,8 @@ metadata:
       || "requirements.json".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: ansible
-    appstudio.openshift.io/component: artifact-signer-ansible
+    appstudio.openshift.io/application: ansible-v1-3
+    appstudio.openshift.io/component: artifact-signer-ansible-v1-3
     pipelines.appstudio.openshift.io/type: build
   name: artifact-signer-ansible-on-push
   namespace: rhtas-tenant


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the appstudio.openshift.io/application and appstudio.openshift.io/component labels in both pull-request and push pipeline configurations to use ansible-v1-3 and artifact-signer-ansible-v1-3