### PR TITLE
chore: Update collection version

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: redhat
 name: artifact_signer
-version: 1.3.0
+version: 1.3.1
 
 readme: README.md
 authors:

--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -1,6 +1,6 @@
 <!--- to update this file, update files in the role's meta/ directory (and/or its README.j2 template) and run "make role-readme" -->
 # Ansible Role: redhat.artifact_signer.tas_single_node
-Version: 1.3.0
+Version: 1.3.1
 
 Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_artifact_signer) service on a single managed node by using the `tas_single_node` role.
  Requires RHEL 9.4 or later.


### PR DESCRIPTION
## Summary by Sourcery

Bump the collection version to 1.3.1 and update the role README to match

Chores:
- Update collection version in galaxy.yml from 1.3.0 to 1.3.1
- Update tas_single_node role README version to 1.3.1