### PR TITLE
Updating WebServer and Readme

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -37,7 +37,7 @@ tas_single_node_trillian_db_image:
 tas_single_node_tuf_image:
   "registry.redhat.io/rhtas/tuffer-rhel9@sha256:0c69e80b59c34a27080fccd7ee7868b3b28b40cfca16aad10b2bcb435528198a"
 tas_single_node_http_server_image:
-  "registry.redhat.io/ubi9/httpd-24@sha256:71aa7d571ff8f1abd1bf0dcfc267002ce118851a45e653dd305e0aadb44d13f8"
+  "registry.redhat.io/ubi9/httpd-24@sha256:4f3476ef3cc15b2474775fd038929f99c8e369210d597b6b71ac3f97084573ef"
 tas_single_node_trillian_netcat_image:
   "registry.redhat.io/openshift4/ose-tools-rhel9@sha256:b2873114e9da894239de944828f07c4fba21aac0224d802acc47aef5ce161b41"
 tas_single_node_nginx_image:


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Refresh the tas_single_node_http_server_image reference to point to the latest approved ubi9 httpd-24 image digest.