### PR TITLE
fix: pipeline indentation

### DIFF
--- a/.tekton/artifact-signer-ansible-pull-request.yaml
+++ b/.tekton/artifact-signer-ansible-pull-request.yaml
@@ -51,7 +51,7 @@ spec:
   taskRunTemplate:
     serviceAccountName: build-pipeline-artifact-signer-ansible
   workspaces:
-    - name: git-auth
-      secret:
-        secretName: '{{ git_auth_secret }}'
-  status: {}
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/artifact-signer-ansible-push.yaml
+++ b/.tekton/artifact-signer-ansible-push.yaml
@@ -48,7 +48,7 @@ spec:
   taskRunTemplate:
     serviceAccountName: build-pipeline-artifact-signer-ansible
   workspaces:
-    - name: git-auth
-      secret:
-        secretName: '{{ git_auth_secret }}'
-  status: {}
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary by Sourcery

Fix Tekton pipeline configuration indentation for artifact signer Ansible pipelines.

Bug Fixes:
- Correct YAML indentation for the git-auth workspace and status fields in artifact-signer Ansible pull request and push Tekton pipelines to ensure valid pipeline configuration.

CI:
- Adjust Tekton pipeline YAML structure for artifact-signer Ansible pull request and push workflows to conform to expected schema.