### PR TITLE
chore: enable pipeline run on testing-requirements changes

### DIFF
--- a/.tekton/artifact-signer-ansible-pull-request.yaml
+++ b/.tekton/artifact-signer-ansible-pull-request.yaml
@@ -10,7 +10,8 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main" && (".tekton/artifact-signer-ansible-pull-request.yaml".pathChanged() || "Dockerfile".pathChanged()
-      || "roles/***".pathChanged() || "meta/***".pathChanged() || "molecule/***".pathChanged()
+      || "roles/***".pathChanged() || "meta/***".pathChanged()
+      || "molecule/***".pathChanged() || "testing-requirements.txt".pathChanged()
       || "requirements.json".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/artifact-signer-ansible-push.yaml
+++ b/.tekton/artifact-signer-ansible-push.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main" && (".tekton/artifact-signer-ansible-push.yaml".pathChanged() || "Dockerfile".pathChanged()
       || "roles/***".pathChanged() || "meta/***".pathChanged()
+      || "molecule/***".pathChanged() || "testing-requirements.txt".pathChanged()
       || "requirements.json".pathChanged())
   creationTimestamp: null
   labels:


### PR DESCRIPTION
## Summary by Sourcery

Update Tekton Pipelines-as-Code triggers to run the artifact-signer Ansible pipelines when additional files change.

CI:
- Trigger the pull request artifact-signer Ansible pipeline when molecule tests or testing requirements change.
- Trigger the push artifact-signer Ansible pipeline when molecule tests or testing requirements change.