### PR TITLE
chore(deps): Pin ansible-core version for testing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,12 @@
             "datasourceTemplate": "docker",
             "versioningTemplate": "redhat"
         }
+    ],
+    "packageRules": [
+        {   "description" : "Pin ansible-core version <2.20 (not supported on RHEL9)",
+            "matchFileNames": ["testing-requirements.txt"],
+            "matchPackageNames": ["ansible-core", "boto3", "botocore", "awscli", "ansible-lint"],
+            "enabled": false
+        }
     ]
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add Renovate package rules to disable dependency updates

- Pin ansible-core and related packages in testing requirements

- Prevent version upgrades incompatible with RHEL9


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["renovate.json"] -- "Add packageRules section" --> B["Disable updates for ansible-core<br/>boto3, botocore, awscli,<br/>ansible-lint in testing-requirements.txt"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Add Renovate package rules for ansible-core pinning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

<ul><li>Add <code>packageRules</code> section to Renovate configuration<br> <li> Disable automatic dependency updates for ansible-core and related AWS <br>packages<br> <li> Target <code>testing-requirements.txt</code> file specifically<br> <li> Include comment explaining RHEL9 compatibility constraint</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/artifact-signer-ansible/pull/516/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

