### PR TITLE
:robot: [RHTAS-build-bot] [release-1.3] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -17,25 +17,25 @@ tas_single_node_trust_root:
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:b19900ebbf9cac67196127a60ea2434a8ce2011b17bab15a0e7fc96cf38a63fa"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:6c97f4f492f898cca124d8f48e7da6444c4c0bb59624c5a339f96224535c5ae1"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:ca6b8828b51a029aa84ebe38f6b58443c85f1614fd24b6de4e82ae2e4dbeecd8"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:90674e8db38ab75a6badf4baa8d5ad482de41d94a24714017b86a4c18cf798fb"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:9e37877e090ff45151a2906538e833a9dcfbb93f933e687532272c927ead7510"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:5389e329ac62721677454060336c0fee58f1e70bffaf49643216ab02b5290b90"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:799b0b86f83f0fdf450ecbd2726419570b15f6ec5ba5b814750d45b8269e4dac"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:edba54af3d4a48b53d287146dffecd513e70271b83b6211401406f2077840d87"
 tas_single_node_rekor_monitor_image:
-  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:5f75a027de5949aea7727f0d00761a7f1592dd46cd7fec9638dc3e1ba744eb96"
+  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:d172191a0643a7d72aba63263e6e6f3432cdbcd4dc16207204cab16cef6e04c7"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:a9bdf1093c50094bb597961c5f395b51bef3758552d14b8b5bc5bf33006de330"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:b678f21f299e4c27d599d6a38eecaa454a44b20b3f9f2ebcd870a8f186d55903"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:58ef574fda207b044885fd26b189408e673c7cd213c2635369ce44418bdc2b69"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:f79d9081ea2d98adeb2545a4c5b71a4c90704feb766584449529fae5fb9e8ed8"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:57f1db8dd5e9cb42078a20c065c1f3052175a88d77b656f4c8e903ab40088303"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:f6bd6ef3999bbd7112571cbe5173f94b3b904b56160759b2500dc9cdc82d969d"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:5d4406c708b15a517d2da83923651f62a1d9cc6d37e45bc2a42808b69a3d04c4"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:1f1260b3ed546ec0cbfd07af1ccd788379071d63beb3039bcaacd4503de7e09d"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:0c69e80b59c34a27080fccd7ee7868b3b28b40cfca16aad10b2bcb435528198a"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:4c69be4a3a308439a8bd1bbf11d31e24a3c2e67361fca593825c11ffe4c79ab0"
 tas_single_node_http_server_image:
   "registry.redhat.io/ubi9/httpd-24@sha256:b17ddeb1f842621a4a94460e12e4180deac418c4b11df350d16b41dd2cbd5505"
 tas_single_node_trillian_netcat_image:
@@ -43,15 +43,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:a75f10d71969dd2451914df6539dea28f8e2c88506f691ea211768a0bd0746d1"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:7b3eb9108c50321278ccad2032b3fb365911df83084cca953dd068cdd51f7874"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:47a3a6a828cdbff2afba0bc64f0061fea3a60bdf82c1331b370acd55c277a6fc"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:199c8a3ade4bd87affdc5a756bd59ed22fdf579c7b4d2bb800a09da3915a8868"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:80921b162efea8e5640a96067cef45b9add2b0837f7db74a7f512d0a99f0e185"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:be3fcfdbd7a6bae84c2447819e9807aedd36138463b1d73269b3d1814941236b"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:64f8224699f677512ad559b66f282594e88ca72082e15d3ac0a415c31ab6b05b"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:cddda466bc9957f1c3902da3a0cf37ef3ec08f4aeb8c50a421405540120b75cf"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:09f6d425223cdb8887423a694ec93edfa0cca6494e9ce8365d736aee27ac0f27"
 
 tas_single_node_podman: {}
 


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `199c8a3` | `80921b1` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `b19900e` | `6c97f4f` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `a9bdf10` | `b678f21` |
| registry.redhat.io/rhtas/createtree-rhel9 | `be3fcfd` | `64f8224` |
| registry.redhat.io/rhtas/rekor-monitor-rhel9 | `5f75a02` | `d172191` |
| registry.redhat.io/rhtas/client-server-rhel9 | `cddda46` | `09f6d42` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `7b3eb91` | `47a3a6a` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `799b0b8` | `edba54a` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `ca6b882` | `90674e8` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `5d4406c` | `1f1260b` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `57f1db8` | `f6bd6ef` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `9e37877` | `5389e32` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `0c69e80` | `4c69be4` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `58ef574` | `f79d908` |
---