### PR TITLE
:robot: [RHTAS-build-bot] [release-1.2] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -17,23 +17,23 @@ tas_single_node_trust_root:
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:6270ba29adf779de5d3916d5e82f1cd9491ba89d4ae2042347b6ad6d1819dd26"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:f4c86a4e6a58a078d8b87f8821e0b336f292690375e49cbc07d4f8ca9964d888"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:12b438ea70f83ee6edb12c96b507f92510f4afba824eac34c8f50793c4199db6"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:c399b5c1d43c5e16f5b0886c59b1480d2619a4125acbcf4db49a687a3c59432b"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:1d782a127d2f8bdab633f287cb2df2e400ae91bf5d4b913473539d8512dfaab6"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:039063b7b019e931c5370bde0d98f9594782b7ede859971133f078ced31076d0"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:02fbd4772c185edf38fcee4e5c5e1c9dad82b77c9da824addaebc445b67d35ac"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:3c7381faf54ca4c59c981ce6a2c7cd59f5db124801f2c78689e0e5c934cf911d"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:eb38e98dbb9828fe033a5388609132f7246fe77d2f4d258d015a94ea30752b24"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:cf9f9b51686a3d5960eaf8e1f0bdabb186712624aa67f7f1bd07dc775139c282"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:fc018a45b7eb48690c46c83f52cac55fa40089e6b02686bc21265dc7c2205b8f"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:0370b5238d68631d3e9db0ff41e79fd2b53fcba8b224accfaab177cab1e89704"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:09b4aeeb607c88c72f69e6f87cb840c82ef5752c64a58fa13551db749fac2530"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:9d6b993562b04338bbdfefe005800dd35b03c5256ff5acf2e5fcf190a79514f9"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:640633823a54c11fe2a8b3d05e571399fda415b6f0b3adf1ba9806882a94bdd4"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:cb974500d58b4c00807fa649e1bb70f35315af5034dc9f3dad07d43e4e3dc859"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:a93df3206409de75613d398e7dcd8b30ff7cc36eb00349c435784f73f00a2335"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:d76e77120bb61e3dc624783adc921d29192696f95698ea0d96642d8369f9e4c3"
 tas_single_node_http_server_image:
   "registry.redhat.io/ubi9/httpd-24@sha256:47a0b3f12211320d1828524a324ab3ec9deac97c17b9d3f056c87d3384d9eb79"
 tas_single_node_trillian_netcat_image:
@@ -41,15 +41,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:f3e0afbc6e1459a63b87ded4666b6ea3fa59a5d146d6bfa39995af936b1fb9f3"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:531603563c69aac6905cd6b8157d30781040527404ac2313acba5a9310e0b713"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:0b90598c0916413a0df1a67e42abd64843e6426f0920f7d157448fc56fe59eae"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:fe31830df2d99359749cb86cd1ac2f32fcc3de07aae427d2f2cd3998d31d2833"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:add1b50cb7c77e874cb3b21330d2d4206e13c5b00824a56e044e5da71a0774f0"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:812315ab0ef006799ebe158dff67773b56d5d5e86d07dee9341214d1b49f4542"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:936421f3a22d979a61aa3e736e62191f1bd46c1d2be1956ac99cb23c6306354e"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:1c2201d50469d70ec6e21546c7c74bd52251d420dc1dcfa5375c1cf61dd3a9fd"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:556b082c1ea6f294b16c1a7140859699749e4455afc58e6a831fbe453c090bff"
 
 tas_single_node_podman: {}
 


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `fe31830` | `add1b50` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `6270ba2` | `f4c86a4` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `eb38e98` | `cf9f9b5` |
| registry.redhat.io/rhtas/createtree-rhel9 | `812315a` | `936421f` |
| registry.redhat.io/rhtas/client-server-rhel9 | `1c2201d` | `556b082` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `5316035` | `0b90598` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `02fbd47` | `3c7381f` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `12b438e` | `c399b5c` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `6406338` | `cb97450` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `09b4aee` | `9d6b993` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `1d782a1` | `039063b` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `a93df32` | `d76e771` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `fc018a4` | `0370b52` |
---