### PR TITLE
chore: fix the ansible core version, copied from main/release-1.3

### DIFF
--- a/roles/tas_single_node/README.md
+++ b/roles/tas_single_node/README.md
@@ -1,6 +1,6 @@
 <!--- to update this file, update files in the role's meta/ directory (and/or its README.j2 template) and run "make role-readme" -->
 # Ansible Role: redhat.artifact_signer.tas_single_node
-Version: 1.2.0
+Version: 1.2.1
 
 Deploy the [RHTAS](https://docs.redhat.com/en/documentation/red_hat_trusted_artifact_signer) service on a single managed node by using the `tas_single_node` role.
  Requires RHEL 9.4 or later.

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,3 +1,6 @@
+# cap ansible-core version at 2.19.0 until https://github.com/ansible/ansible-lint/pull/4683
+# is released otherwise ansible-lint fails
+ansible-core>=2.16.0,<2.19.0
 ansible-lint==25.1.2
 antsibull-docs==2.16.3
 awscli==1.38.9


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Cap `ansible-core` version at 2.19.0 to prevent ansible-lint failures

- Add explanatory comment referencing pending ansible-lint PR fix

- Specify version constraint `>=2.16.0,<2.19.0` in testing requirements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["testing-requirements.txt"] -- "Add ansible-core version constraint" --> B["ansible-core>=2.16.0,<2.19.0"]
  A -- "Add explanatory comment" --> C["Reference ansible-lint PR #4683"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testing-requirements.txt</strong><dd><code>Add ansible-core version constraint with explanation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

testing-requirements.txt

<ul><li>Added version constraint for <code>ansible-core</code> to cap at 2.19.0<br> <li> Added explanatory comment referencing pending ansible-lint PR #4683<br> <li> Constraint prevents ansible-lint failures with newer ansible-core <br>versions</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/artifact-signer-ansible/pull/563/files#diff-053da9e337ebd9741e9a75830116a60b8149a7c432d053e5e7442da44668ce78">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

