### PR TITLE
:robot: [RHTAS-build-bot] [release-1.3] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -17,25 +17,25 @@ tas_single_node_trust_root:
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:6c97f4f492f898cca124d8f48e7da6444c4c0bb59624c5a339f96224535c5ae1"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:d876a5e41b8467cdde921032f2cd53e77bef99ebcd8b61d72a3ad411469ad352"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:90674e8db38ab75a6badf4baa8d5ad482de41d94a24714017b86a4c18cf798fb"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:7c6cba78fb26addd9f056ec3f8b9376666db353451da37a4681a51d16f2ff76c"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:5389e329ac62721677454060336c0fee58f1e70bffaf49643216ab02b5290b90"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:83a8710df2032471c379f4cfbb3861ec9c4c7794f8b487483dbfb8cf57207750"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:edba54af3d4a48b53d287146dffecd513e70271b83b6211401406f2077840d87"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:9746960bbc79e0ecf82a0ee12f878e90e202247dcaeb046bdd11db48a52ccb90"
 tas_single_node_rekor_monitor_image:
-  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:d172191a0643a7d72aba63263e6e6f3432cdbcd4dc16207204cab16cef6e04c7"
+  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:f8fe656e4d4f8c2e801ebfa829770928520f411327eb3776b80d1012200933a2"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:b678f21f299e4c27d599d6a38eecaa454a44b20b3f9f2ebcd870a8f186d55903"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:240a9553315990a06a9d52eaf6e96e3aa1c743f1fbff33b95b489d41cef18f5a"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:f79d9081ea2d98adeb2545a4c5b71a4c90704feb766584449529fae5fb9e8ed8"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:7261ee18d6fd8d42614e94ae3bdb77c5acad54f2b9898365bf8668c60a32589a"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:f6bd6ef3999bbd7112571cbe5173f94b3b904b56160759b2500dc9cdc82d969d"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:ec50096d68a499e7f605bcfa7afd30845a03e0c4849736431f6752fa8b850897"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:1f1260b3ed546ec0cbfd07af1ccd788379071d63beb3039bcaacd4503de7e09d"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:f4e92bf3f35d86fe895a2e3225098b3d4d9dae720ef1d45e9efcf23dec8242b6"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:4c69be4a3a308439a8bd1bbf11d31e24a3c2e67361fca593825c11ffe4c79ab0"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:89c686659b2276825a7109717ec3326b7a2054d48dae50ae41407744ae26d1aa"
 tas_single_node_http_server_image:
   "registry.redhat.io/ubi9/httpd-24@sha256:db1e58bcd8e271e0bddd1f4eb561918c4ff0927416993061eab79edfbbf50d4d"
 tas_single_node_trillian_netcat_image:
@@ -43,15 +43,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:a75f10d71969dd2451914df6539dea28f8e2c88506f691ea211768a0bd0746d1"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:47a3a6a828cdbff2afba0bc64f0061fea3a60bdf82c1331b370acd55c277a6fc"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:37b9359f11098a781158e5bc0850ec43b599d29a354b43745067656b0a234814"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:80921b162efea8e5640a96067cef45b9add2b0837f7db74a7f512d0a99f0e185"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:3971738912069448174202486b61ed384153ca18af3e8430a55795a6e65eb58d"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:64f8224699f677512ad559b66f282594e88ca72082e15d3ac0a415c31ab6b05b"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:e8f95dc51266292cc1909ee11ba97c8e8e112af063b257814fe66f1a3894d267"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:09f6d425223cdb8887423a694ec93edfa0cca6494e9ce8365d736aee27ac0f27"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:39c72cf5b519408d1659bb630ac4ea5f9d067b049019fe4d1b5cc7680afa9060"
 
 tas_single_node_podman: {}
 


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `80921b1` | `3971738` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `6c97f4f` | `d876a5e` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `b678f21` | `240a955` |
| registry.redhat.io/rhtas/createtree-rhel9 | `64f8224` | `e8f95dc` |
| registry.redhat.io/rhtas/rekor-monitor-rhel9 | `d172191` | `f8fe656` |
| registry.redhat.io/rhtas/client-server-rhel9 | `09f6d42` | `39c72cf` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `47a3a6a` | `37b9359` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `edba54a` | `9746960` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `90674e8` | `7c6cba7` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `1f1260b` | `f4e92bf` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `f6bd6ef` | `ec50096` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `5389e32` | `83a8710` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `4c69be4` | `89c6866` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `f79d908` | `7261ee1` |
---