### PR TITLE
:robot: [RHTAS-build-bot] [release-1.2] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -17,23 +17,23 @@ tas_single_node_trust_root:
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:f4c86a4e6a58a078d8b87f8821e0b336f292690375e49cbc07d4f8ca9964d888"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:c9289244939c0fd2737e8768ac089d09d15ca42ea34e2512c13a73c159338ab7"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:c399b5c1d43c5e16f5b0886c59b1480d2619a4125acbcf4db49a687a3c59432b"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:b246d096ad6d2b19decfa3d87bca9ab2b78000aee28b717c0a33d1202a1b2d6b"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:039063b7b019e931c5370bde0d98f9594782b7ede859971133f078ced31076d0"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:d0f8b68e55173b010fd381e374f232a40fba6d03282cfd870bd9c12c492e4aec"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:3c7381faf54ca4c59c981ce6a2c7cd59f5db124801f2c78689e0e5c934cf911d"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:4afca53f27929243177a80a08e1ca77bd8978a50e8e0e7929781bb7b14a85cd2"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:cf9f9b51686a3d5960eaf8e1f0bdabb186712624aa67f7f1bd07dc775139c282"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:7e70be684d2bc550f1d31b89eadcac24e6385b3578ad29d8bdaa17b260f9dbce"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:0370b5238d68631d3e9db0ff41e79fd2b53fcba8b224accfaab177cab1e89704"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:d97e6688aabf25ed1da6a8bf2012efb1772beed49b91456288418f6023a38dac"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:9d6b993562b04338bbdfefe005800dd35b03c5256ff5acf2e5fcf190a79514f9"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:9b91bac976cf7c30b15f9a022996142e48711110ecd1c52663504e53dcfdcf09"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:cb974500d58b4c00807fa649e1bb70f35315af5034dc9f3dad07d43e4e3dc859"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:50bc20bb57e8ee31e56637cafccfed2658982d81ca9bf1e71db9de4b82a2be36"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:d76e77120bb61e3dc624783adc921d29192696f95698ea0d96642d8369f9e4c3"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:743bbe6b3a666225eb8ac30f667d20f3daeb0586a6c2d7005d3096c0e823dac5"
 tas_single_node_http_server_image:
   "registry.redhat.io/ubi9/httpd-24@sha256:47a0b3f12211320d1828524a324ab3ec9deac97c17b9d3f056c87d3384d9eb79"
 tas_single_node_trillian_netcat_image:
@@ -41,15 +41,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:f3e0afbc6e1459a63b87ded4666b6ea3fa59a5d146d6bfa39995af936b1fb9f3"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:0b90598c0916413a0df1a67e42abd64843e6426f0920f7d157448fc56fe59eae"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:576d4fc358fffe5bedb93eb3fec68b9c040b1d50e6c4c56a3f8d49084c169e4f"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:add1b50cb7c77e874cb3b21330d2d4206e13c5b00824a56e044e5da71a0774f0"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:1e3a46ade52215e2c78df9229f36301c94099e8397ee74ab99fb8bd504ce7aa2"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:936421f3a22d979a61aa3e736e62191f1bd46c1d2be1956ac99cb23c6306354e"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:7a1e465f93e0560194b7d5d27b46453a0dd4ebb4072235da1ffbe4ccff91d452"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:556b082c1ea6f294b16c1a7140859699749e4455afc58e6a831fbe453c090bff"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:47071a0613d6d262110af4ce6703ce99db72c7ab58e3a6051b82f3098b372a49"
 
 tas_single_node_podman: {}
 


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `add1b50` | `1e3a46a` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `f4c86a4` | `c928924` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `cf9f9b5` | `7e70be6` |
| registry.redhat.io/rhtas/createtree-rhel9 | `936421f` | `7a1e465` |
| registry.redhat.io/rhtas/client-server-rhel9 | `556b082` | `47071a0` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `0b90598` | `576d4fc` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `3c7381f` | `4afca53` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `c399b5c` | `b246d09` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `cb97450` | `50bc20b` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `9d6b993` | `9b91bac` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `039063b` | `d0f8b68` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `d76e771` | `743bbe6` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `0370b52` | `d97e668` |
---