### PR TITLE
:robot: [RHTAS-build-bot] [release-1.3] Update Component images

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -17,25 +17,25 @@ tas_single_node_trust_root:
 # To avoid breaking our structural tests
 
 tas_single_node_fulcio_server_image:
-  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:d876a5e41b8467cdde921032f2cd53e77bef99ebcd8b61d72a3ad411469ad352"
+  "registry.redhat.io/rhtas/fulcio-rhel9@sha256:019a405b36f778c89b23215c7babdebb4998ee5c8025419cf5bfde352559dc14"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:7c6cba78fb26addd9f056ec3f8b9376666db353451da37a4681a51d16f2ff76c"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:e73446488e50a95966cc6357707ef411fa90eed551b24153f6783809c20b1382"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:83a8710df2032471c379f4cfbb3861ec9c4c7794f8b487483dbfb8cf57207750"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:05d5b67e06e263d35d27313fb88e445575d17955532c47ff9c29435955874247"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:9746960bbc79e0ecf82a0ee12f878e90e202247dcaeb046bdd11db48a52ccb90"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:aafcf55f045ccbcc2b2e417ec7fbd77849277e4c234dccfdd9c0196e2c3da3f3"
 tas_single_node_rekor_monitor_image:
-  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:f8fe656e4d4f8c2e801ebfa829770928520f411327eb3776b80d1012200933a2"
+  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:a02c0018cc999085def7eb4276f06067e138a9249cc72f29453f25fd52266a10"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:240a9553315990a06a9d52eaf6e96e3aa1c743f1fbff33b95b489d41cef18f5a"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:7cbf14ea99833ce62d6a6a60da1d59300aac9641860ff9972a777138f8a585f5"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:7261ee18d6fd8d42614e94ae3bdb77c5acad54f2b9898365bf8668c60a32589a"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:0df100776e3e902d7c33e1778e185d91e84c27a6a36c2a441a1835eb081f0fbb"
 tas_single_node_backfill_redis_image:
-  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:ec50096d68a499e7f605bcfa7afd30845a03e0c4849736431f6752fa8b850897"
+  "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:5a4d12ce4bd320f47fe5ad643ff39ed797f5ec6b646dbbdf5f02d8aadf0d1e8e"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:f4e92bf3f35d86fe895a2e3225098b3d4d9dae720ef1d45e9efcf23dec8242b6"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:95037e0d7dd256281ea7f0684f29b3f899f5809143c19641a42e504dde24e3f3"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:89c686659b2276825a7109717ec3326b7a2054d48dae50ae41407744ae26d1aa"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:3b8a9fe72de410ba297d4704c6034adcb0b79a6fc4c429b4aadc2e41e0ed70bb"
 tas_single_node_http_server_image:
   "registry.redhat.io/ubi9/httpd-24@sha256:db1e58bcd8e271e0bddd1f4eb561918c4ff0927416993061eab79edfbbf50d4d"
 tas_single_node_trillian_netcat_image:
@@ -43,15 +43,15 @@ tas_single_node_trillian_netcat_image:
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:a75f10d71969dd2451914df6539dea28f8e2c88506f691ea211768a0bd0746d1"
 tas_single_node_timestamp_authority_image:
-  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:37b9359f11098a781158e5bc0850ec43b599d29a354b43745067656b0a234814"
+  "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:4aaaba427fc70fa23534669b630953be0bd4c3f2225219a5c33f853ba24f1f0b"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:3971738912069448174202486b61ed384153ca18af3e8430a55795a6e65eb58d"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:46234ee7268c0617c43881af1a2c651ade2e4df94e4f9a3c8114c8f06b965a98"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:e8f95dc51266292cc1909ee11ba97c8e8e112af063b257814fe66f1a3894d267"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:dba7e86e1cce9c0fa8b79367cf9840a2ac954e97b3e76335677036c5781d5164"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:39c72cf5b519408d1659bb630ac4ea5f9d067b049019fe4d1b5cc7680afa9060"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:aa0def9f7b28ded761ce921972db01013085ed798b054c5a416fbe35fcde7ee8"
 
 tas_single_node_podman: {}
 


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rekor-search-ui-rhel9 | `3971738` | `46234ee` |
| registry.redhat.io/rhtas/fulcio-rhel9 | `d876a5e` | `019a405` |
| registry.redhat.io/rhtas/certificate-transparency-rhel9 | `240a955` | `7cbf14e` |
| registry.redhat.io/rhtas/createtree-rhel9 | `e8f95dc` | `dba7e86` |
| registry.redhat.io/rhtas/rekor-monitor-rhel9 | `f8fe656` | `a02c001` |
| registry.redhat.io/rhtas/client-server-rhel9 | `39c72cf` | `aa0def9` |
| registry.redhat.io/rhtas/timestamp-authority-rhel9 | `37b9359` | `4aaaba4` |
| registry.redhat.io/rhtas/rekor-server-rhel9 | `9746960` | `aafcf55` |
| registry.redhat.io/rhtas/trillian-logserver-rhel9 | `7c6cba7` | `e734464` |
| registry.redhat.io/rhtas/trillian-database-rhel9 | `f4e92bf` | `95037e0` |
| registry.redhat.io/rhtas/rekor-backfill-redis-rhel9 | `ec50096` | `5a4d12c` |
| registry.redhat.io/rhtas/trillian-logsigner-rhel9 | `83a8710` | `05d5b67` |
| registry.redhat.io/rhtas/tuffer-rhel9 | `89c6866` | `3b8a9fe` |
| registry.redhat.io/rhtas/trillian-redis-rhel9 | `7261ee1` | `0df1007` |
---