### PR TITLE
Update release-version to 1.3.5

### DIFF
--- a/.tekton/artifact-signer-ansible-pull-request.yaml
+++ b/.tekton/artifact-signer-ansible-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   params:
     - name: release-version
-      value: "1.3.2"
+      value: "1.3.5"
     - name: git-url
       value: '{{source_url}}'
     - name: revision

--- a/.tekton/artifact-signer-ansible-push.yaml
+++ b/.tekton/artifact-signer-ansible-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
     - name: release-version
-      value: "1.3.4"
+      value: "1.3.5"
     - name: git-url
       value: '{{source_url}}'
     - name: revision


### PR DESCRIPTION
## Summary
- Update release-version parameter from 1.3.2/1.3.4 to 1.3.5 in Tekton pipeline files

## Test plan
- Verify Tekton pipelines run with version 1.3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)