### PR TITLE
Update release-version to 1.3.6

### DIFF
--- a/.tekton/artifact-signer-ansible-pull-request.yaml
+++ b/.tekton/artifact-signer-ansible-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   params:
     - name: release-version
-      value: "1.3.5"
+      value: "1.3.6"
     - name: git-url
       value: '{{source_url}}'
     - name: revision

--- a/.tekton/artifact-signer-ansible-push.yaml
+++ b/.tekton/artifact-signer-ansible-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
     - name: release-version
-      value: "1.3.5"
+      value: "1.3.6"
     - name: git-url
       value: '{{source_url}}'
     - name: revision


### PR DESCRIPTION
## Summary
Update the release-version parameter in Tekton pipeline definitions to 1.3.6 for the release-1.3 branch.

## Changes
- Updated release-version parameter from previous version to 1.3.6 in .tekton/ pipeline files

## Testing
- Verify pipeline parameter is correctly set
- Ensure pipelines can be triggered with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)