### PR TITLE
Update image digests for 1.4.3 release

### DIFF
--- a/roles/tas_single_node/defaults/main.yml
+++ b/roles/tas_single_node/defaults/main.yml
@@ -19,41 +19,41 @@ tas_single_node_trust_root:
 tas_single_node_fulcio_server_image:
   "registry.redhat.io/rhtas/fulcio-rhel9@sha256:5395edc0795b38375f8d8480ac77ea26ad41aac60f89e8b68537bc4f1a6e360b"
 tas_single_node_trillian_log_server_image:
-  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:6cac09fcce3938f4e08e0dc5960ca5159bd4c36d238e1e49037c977c62dde85d"
+  "registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:aa8b1b40423856e4ee72bd16365f94819345b3144d9ce66a3afc634c447fca4f"
 tas_single_node_trillian_log_signer_image:
-  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:613398e5394371bac97d05c04d97b163c5048a8095ff8ff8bc510a24e46092d6"
+  "registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:d2b774d9e7962500e24bb6c629ea2e62a4d46ed2a9c1dd240a7c1dbb75def3c9"
 tas_single_node_rekor_server_image:
-  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:938ca7e6d7fa3862825a86f142be9c6a7b5da1f7dfc6393bff5f77e24613bf67"
+  "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:29d95400864ec7bef421fd5fb180138feed8eb5d796f2f4bd8e4178722b655f6"
 tas_single_node_rekor_monitor_image:
-  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:3d551907e5a5b7fe8ca110d273a02f60296dbc3ca512af3a80715e9cfc4477e8"
+  "registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:a40a4a303b4d5755f62103dfc55c773c4e63f6955334a52435f493d81265c13b"
 tas_single_node_ctlog_image:
-  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:428e9da9c20b26a5ba88ec84f1be212ce0474f81c2fd56ac062e3948eb23070d"
+  "registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:37cc3179946c699bb78e775a3d514bf92873424559d9cebf35e0a5812256f5b7"
 tas_single_node_ctlog_monitor_image:
-  "registry.redhat.io/rhtas/ctlog-monitor-rhel9@sha256:4502f26fff1b13763ddb7a6cc66a81cab407589b75409b2c5455c12bc2643517"
+  "registry.redhat.io/rhtas/ctlog-monitor-rhel9@sha256:8c51a84b03c365fd9e3858471efd3fc6a92107544a845ea2a6df315263c1eb6d"
 tas_single_node_rekor_redis_image:
-  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:fd4c05777a37475158316b694d4319c0a8ea0e39838306ee73523ec37fd3f3fa"
+  "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:935ab04c208b93577b864587adab23fcfc66135d84417440a86da980ea9bcd3a"
 tas_single_node_backfill_redis_image:
   "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:9bbed4541cf2305ec915c39b51c1103524e68841d98178c61bf841fd5ccc504b"
 tas_single_node_trillian_db_image:
-  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:b5736b9f843573e1820b25da162b537b5f324d437c78a79c54f5258fa2204521"
+  "registry.redhat.io/rhtas/trillian-database-rhel9@sha256:df92c04caca9fcfd76bc9cdf0e86c211fbe2f4a58e92101fddd8764aee63a107"
 tas_single_node_tuf_image:
-  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:476507f32b60f981b0a01187636deaf1cace3e7177b057332b054cff18fcd526"
+  "registry.redhat.io/rhtas/tuffer-rhel9@sha256:3dbd01bd144a94c7662f646bcd98220a65d218391dc4b1be282c6618d8eb2b1c"
 tas_single_node_http_server_image:
-  "registry.redhat.io/ubi9/httpd-24@sha256:b660a5ca52c587e459969d34c7dafaa989159da3c7dd1828d9c7159915974163"
+  "registry.redhat.io/ubi9/httpd-24@sha256:66b14ae828342819823fe01bc93117b54ce3999eaee8bc608de0be7459abc65b"
 tas_single_node_trillian_netcat_image:
-  "registry.redhat.io/openshift4/ose-tools-rhel9@sha256:17d4647d21d7571c11d6f983400da6544376fe8bde8372776e4779ebd8c6fd53"
+  "registry.redhat.io/openshift4/ose-tools-rhel9@sha256:52da0e4461897bbd0d4ab6f3340e290de5d6b9a702014950b4db6b6abb4880f4"
 tas_single_node_nginx_image:
   "registry.redhat.io/rhel9/nginx-124@sha256:fc163d9e8d58caad8efa88c43272c95486194cfa6356dd0bdb44ba60f51d96a5"
 tas_single_node_timestamp_authority_image:
   "registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:b71b536a4f70e70df2ec9ee03d373a76e5b505de3513c46bcdcb799b1103685b"
 tas_single_node_rekor_search_ui_image:
-  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:c0dfe2abf8d55740eefbaa647de617d1f796390111fae05919bf77897763977b"
+  "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:fb0f828b264e330a74db15da96c992fc21f4ba1fbc1884b334f6eca89ddf3344"
 # Create Tree
 tas_single_node_createtree_image:
-  "registry.redhat.io/rhtas/createtree-rhel9@sha256:5d8b2c4d34b2ee4c51e2786dd200c16a5741cf8a8af48654f290505967fffc8d"
+  "registry.redhat.io/rhtas/createtree-rhel9@sha256:0e90e4219ab0e8b7ee0e77108c87fea8f699f5c2bac28e8fd3f5b4ff867147f6"
 # CLI Server
 tas_single_node_client_server_image:
-  "registry.redhat.io/rhtas/client-server-rhel9@sha256:050f362dc6b245851e58348e82a057fac7a6efc31e274fe03f3420a440b8ef11"
+  "registry.redhat.io/rhtas/client-server-rhel9@sha256:93df5643ae68ef896371d1278e323f153c906c7049ce0f6ba72fa927e16e272b"
 
 tas_single_node_signing_config_url_mode: external
 


### PR DESCRIPTION
## Summary
- Updated 14 image digests in `roles/tas_single_node/defaults/main.yml` to align with operator `images.env` from July 21 Konflux builds
- All 17 ansible image references now match the operator exactly (3 were already aligned)
- Source of truth: `secure-sign-operator/config/default/images.env` on `release-1.4`

## Images updated
trillian-logserver, trillian-logsigner, rekor-server, rekor-monitor, certificate-transparency, ctlog-monitor, trillian-redis, trillian-database, tuffer, httpd, ose-tools, rekor-search-ui, createtree, client-server

## Test plan
- [ ] Verify digests match operator images.env
- [ ] Ansible molecule tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)